### PR TITLE
Updated ADB Folder Path from C:/ to System Drive

### DIFF
--- a/ADB.cs
+++ b/ADB.cs
@@ -9,7 +9,7 @@ namespace AndroidSideloader
     internal class ADB
     {
         private static readonly Process adb = new Process();
-        public static string adbFolderPath = "%SystemDrive%\\RSL\\platform-tools";
+        public static string adbFolderPath = $"{Path.GetPathRoot(Environment.SystemDirectory)}\\RSL\\platform-tools";
         public static string adbFilePath = adbFolderPath + "\\adb.exe";
         public static string DeviceID = "";
         public static string package = "";

--- a/ADB.cs
+++ b/ADB.cs
@@ -9,7 +9,7 @@ namespace AndroidSideloader
     internal class ADB
     {
         private static readonly Process adb = new Process();
-        public static string adbFolderPath = "C:\\RSL\\platform-tools";
+        public static string adbFolderPath = "%SystemDrive%\\RSL\\platform-tools";
         public static string adbFilePath = adbFolderPath + "\\adb.exe";
         public static string DeviceID = "";
         public static string package = "";


### PR DESCRIPTION
Updated "adbFolderPath" to be adaptable for all cases even when C: is not the system drive

Here A: is system drive instead of C:.
![image](https://github.com/nerdunit/androidsideloader/assets/52963184/32742fd7-707a-4fcd-b427-115c51986b06)
![image](https://github.com/nerdunit/androidsideloader/assets/52963184/7c602ee1-2211-4403-b083-cba5b94aa6b2)