### PR TITLE
Multi-threaded downloads & parallel SFTP OBB transfers with live speeds

### DIFF
--- a/ADB.cs
+++ b/ADB.cs
@@ -532,6 +532,13 @@ namespace AndroidSideloader
                 long totalBytes = files.Sum(f => new FileInfo(f).Length);
                 long transferredBytes = 0;
 
+                // Surface each file in the transfer window (adb push path).
+                var pushItems = new System.Collections.Generic.Dictionary<string, TransferItem>(StringComparer.Ordinal);
+                foreach (var pf in files)
+                {
+                    pushItems[pf] = TransferQueue.Add(Path.GetFileName(pf), "Push", new FileInfo(pf).Length);
+                }
+
                 // Throttle UI updates to prevent lag
                 DateTime pushStartTime = DateTime.UtcNow;
                 DateTime lastProgressUpdate = DateTime.MinValue;
@@ -561,9 +568,17 @@ namespace AndroidSideloader
                         long fileSize = fileInfo.Length;
                         long capturedTransferredBytes = transferredBytes;
 
+                        TransferItem pushItem = pushItems[file];
+                        TransferQueue.SetState(pushItem, TransferState.Active);
+                        DateTime fileStart = DateTime.UtcNow;
+
                         Action<SyncProgressChangedEventArgs> progressHandler = (args) =>
                         {
                             long totalProgressBytes = capturedTransferredBytes + args.ReceivedBytesSize;
+
+                            double feSecs = (DateTime.UtcNow - fileStart).TotalSeconds;
+                            double fileMBps = feSecs > 0.1 ? (args.ReceivedBytesSize / 1048576.0) / feSecs : 0;
+                            TransferQueue.Report(pushItem, args.ReceivedBytesSize, fileMBps);
 
                             float overallPercent = totalBytes > 0
                                 ? (float)(totalProgressBytes * 100.0 / totalBytes)
@@ -608,6 +623,8 @@ namespace AndroidSideloader
                             });
                         }
 
+                        TransferQueue.Report(pushItem, fileSize, 0);
+                        TransferQueue.SetState(pushItem, TransferState.Done);
                         transferredBytes += fileSize;
                     }
                 }

--- a/ADB.cs
+++ b/ADB.cs
@@ -396,6 +396,25 @@ namespace AndroidSideloader
             {
                 Logger.Log($"SideloadWithProgressAsync error: {ex.Message}", LogLevel.ERROR);
 
+                // AdvancedSharpAdbClient throws "An unknown error occurred." whenever it cannot
+                // parse pm install's result - which frequently happens even though the install
+                // actually succeeded (a connection blip right after install, unusual pm output).
+                // Verify against the device before treating it as a failure.
+                try
+                {
+                    if (VerifyInstalled(path, packagename))
+                    {
+                        Logger.Log($"{gameName}: install reported '{ex.Message}', but the package is present on the device with a matching version - treating as success.", LogLevel.WARNING);
+                        progressCallback?.Invoke(100, null);
+                        statusCallback?.Invoke("");
+                        return new ProcessOutput($"{gameName}: Success (verified on device)\n");
+                    }
+                }
+                catch (Exception vex)
+                {
+                    Logger.Log($"Install verification failed: {vex.Message}", LogLevel.WARNING);
+                }
+
                 // Signature mismatches and version downgrades can be fixed by reinstalling
                 bool isReinstallEligible = ex.Message.Contains("signatures do not match") ||
                                            ex.Message.Contains("INSTALL_FAILED_VERSION_DOWNGRADE") ||
@@ -483,6 +502,68 @@ namespace AndroidSideloader
 
                 // Return the error message so it's displayed to the user
                 return new ProcessOutput("", $"\n{gameName}: {ex.Message}");
+            }
+        }
+
+        // Confirms an APK actually installed by checking the device, so a benign "unknown error"
+        // from the install-result parser isn't treated as a real failure. Reads the APK's package
+        // name + version code with aapt and requires the device to report the same version.
+        private static bool VerifyInstalled(string apkPath, string knownPackage)
+        {
+            try
+            {
+                string apkPkg = knownPackage;
+                string apkVc = null;
+
+                string aapt = Path.Combine(adbFolderPath, "aapt.exe");
+                if (File.Exists(aapt) && File.Exists(apkPath))
+                {
+                    var psi = new ProcessStartInfo
+                    {
+                        FileName = aapt,
+                        Arguments = $"dump badging \"{apkPath}\"",
+                        UseShellExecute = false,
+                        CreateNoWindow = true,
+                        RedirectStandardOutput = true,
+                        RedirectStandardError = true
+                    };
+                    using (var p = Process.Start(psi))
+                    {
+                        string outp = p.StandardOutput.ReadToEnd();
+                        p.WaitForExit(10000);
+                        var pm = System.Text.RegularExpressions.Regex.Match(outp, @"package: name='([^']+)'");
+                        if (string.IsNullOrEmpty(apkPkg) && pm.Success) apkPkg = pm.Groups[1].Value;
+                        var vm = System.Text.RegularExpressions.Regex.Match(outp, @"versionCode='(\d+)'");
+                        if (vm.Success) apkVc = vm.Groups[1].Value;
+                    }
+                }
+
+                if (string.IsNullOrEmpty(apkPkg)) return false;
+
+                // Is the package present on the device at all?
+                string listed = RunAdbCommandToString($"shell pm list packages {apkPkg}", true).Output ?? "";
+                if (listed.IndexOf("package:" + apkPkg, StringComparison.OrdinalIgnoreCase) < 0)
+                {
+                    return false;
+                }
+
+                // If we know the APK's version code, require the installed one to match so a
+                // failed *upgrade* (old version still present) is not mistaken for success.
+                if (!string.IsNullOrEmpty(apkVc))
+                {
+                    string devOut = RunAdbCommandToString($"shell \"dumpsys package {apkPkg} | grep versionCode\"", true).Output ?? "";
+                    var dm = System.Text.RegularExpressions.Regex.Match(devOut, @"versionCode=(\d+)");
+                    if (dm.Success)
+                    {
+                        return dm.Groups[1].Value == apkVc;
+                    }
+                }
+
+                return true; // present, versions unknown -> accept
+            }
+            catch
+            {
+                return false;
             }
         }
 

--- a/ADB.cs
+++ b/ADB.cs
@@ -501,6 +501,7 @@ namespace AndroidSideloader
                 long transferredBytes = 0;
 
                 // Throttle UI updates to prevent lag
+                DateTime pushStartTime = DateTime.UtcNow;
                 DateTime lastProgressUpdate = DateTime.MinValue;
                 float lastReportedPercent = -1;
                 const int ThrottleMs = 100; // Update UI every 100ms
@@ -555,7 +556,9 @@ namespace AndroidSideloader
                                 lastProgressUpdate = now2;
                                 lastReportedPercent = overallPercent;
                                 progressCallback?.Invoke(overallPercent, displayEta);
-                                statusCallback?.Invoke(fileName);
+                                double pushElapsed = (now2 - pushStartTime).TotalSeconds;
+                                double pushMBps = pushElapsed > 0.1 ? (totalProgressBytes / 1048576.0) / pushElapsed : 0;
+                                statusCallback?.Invoke($"{fileName} · {pushMBps:0.0} MB/s");
                             }
                         };
 

--- a/ADB.cs
+++ b/ADB.cs
@@ -172,6 +172,78 @@ namespace AndroidSideloader
             }
         }
 
+        // Returns true if the `adb devices` output lists at least one usable device.
+        private static bool HasOnlineDevice(string devicesOutput)
+        {
+            if (string.IsNullOrEmpty(devicesOutput))
+            {
+                return false;
+            }
+
+            string[] lines = devicesOutput.Split('\n');
+            for (int i = 1; i < lines.Length; i++)
+            {
+                string line = lines[i].Trim();
+                if (line.Length == 0)
+                {
+                    continue;
+                }
+                if (line.IndexOf("List of devices", StringComparison.OrdinalIgnoreCase) >= 0)
+                {
+                    continue;
+                }
+                if (line.IndexOf("unauthorized", StringComparison.OrdinalIgnoreCase) >= 0
+                    || line.IndexOf("offline", StringComparison.OrdinalIgnoreCase) >= 0)
+                {
+                    continue;
+                }
+                if (line.IndexOf("device", StringComparison.OrdinalIgnoreCase) >= 0)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        // `adb devices` briefly reports nothing while the daemon is (re)starting - which
+        // happens whenever a different-version adb client (e.g. one in PATH) forces the
+        // server to kill and restart. Reading that transient empty result as a disconnect
+        // is what makes the UI flash "No Device Connected". This retries across the restart
+        // window so a server bounce never registers as a disconnect. Call off the UI thread.
+        public static ProcessOutput GetDevicesResilient(int maxAttempts = 4, int delayMs = 600)
+        {
+            ProcessOutput result = new ProcessOutput("", "");
+            for (int attempt = 0; attempt < maxAttempts; attempt++)
+            {
+                result = RunAdbCommandToString("devices", suppressLogging: true);
+                if (HasOnlineDevice(result.Output))
+                {
+                    return result;
+                }
+
+                string combined = (result.Output ?? "") + (result.Error ?? "");
+                bool daemonRestarting =
+                    combined.IndexOf("daemon not running", StringComparison.OrdinalIgnoreCase) >= 0
+                    || combined.IndexOf("daemon started", StringComparison.OrdinalIgnoreCase) >= 0
+                    || combined.IndexOf("killing", StringComparison.OrdinalIgnoreCase) >= 0
+                    || combined.IndexOf("doesn't match this client", StringComparison.OrdinalIgnoreCase) >= 0
+                    || combined.IndexOf("cannot connect to daemon", StringComparison.OrdinalIgnoreCase) >= 0
+                    || combined.IndexOf("starting now", StringComparison.OrdinalIgnoreCase) >= 0;
+
+                // If the daemon is up and simply reports no device, don't keep waiting.
+                if (!daemonRestarting && attempt >= 1)
+                {
+                    break;
+                }
+
+                if (attempt < maxAttempts - 1)
+                {
+                    System.Threading.Thread.Sleep(delayMs);
+                }
+            }
+            return result;
+        }
+
         // Executes a shell command on the device.
         private static void ExecuteShellCommand(AdbClient client, DeviceData device, string command)
         {
@@ -402,6 +474,15 @@ namespace AndroidSideloader
                 if (device.Serial == null)
                 {
                     return new ProcessOutput("", "No device connected");
+                }
+
+                // Fast path: rooted headsets running an SSH server take OBBs over SFTP,
+                // which is far faster than adb push. Returns null when unavailable.
+                ProcessOutput sftpResult = await SFTP.TryCopyObbWithProgressAsync(
+                    localPath, progressCallback, statusCallback, gameName);
+                if (sftpResult != null)
+                {
+                    return sftpResult;
                 }
 
                 var client = GetAdbClient();

--- a/ADB.cs
+++ b/ADB.cs
@@ -72,7 +72,7 @@ namespace AndroidSideloader
             return _currentDevice;
         }
 
-        public static ProcessOutput RunAdbCommandToString(string command, bool suppressLogging = false)
+        public static ProcessOutput RunAdbCommandToString(string command, bool suppressLogging = false, int timeoutMs = 0)
         {
             if (!File.Exists(adbFilePath))
             {
@@ -101,7 +101,30 @@ namespace AndroidSideloader
             }
 
             bool isConnectCommand = command.Contains("connect");
-            int timeoutMs = isConnectCommand ? 5000 : -1; // 5 second timeout for connect commands
+            // Large transfers and on-device backup/restore prompts can legitimately run
+            // for a long time, so they must never be force-killed. Every other shell
+            // command gets a safety timeout so a wedged device command (e.g. Android's
+            // `df` blocking on an unresponsive mount) can't freeze the app indefinitely.
+            bool isLongOp = command.Contains("pull") || command.Contains("push")
+                            || command.Contains("backup") || command.Contains("restore")
+                            || command.Contains("install");
+            int effectiveTimeout;
+            if (timeoutMs != 0)
+            {
+                effectiveTimeout = timeoutMs; // caller override (-1 = wait forever)
+            }
+            else if (isConnectCommand)
+            {
+                effectiveTimeout = 5000;
+            }
+            else if (isLongOp)
+            {
+                effectiveTimeout = -1;
+            }
+            else
+            {
+                effectiveTimeout = 45000;
+            }
 
             using (Process adb = new Process())
             {
@@ -119,21 +142,30 @@ namespace AndroidSideloader
 
                 try
                 {
-                    if (isConnectCommand)
+                    if (effectiveTimeout > 0)
                     {
-                        // For connect commands, we use async reading with timeout to avoid blocking on TCP timeout
+                        // Async reads + a bounded wait so a wedged device command can't block
+                        // forever (also avoids the classic sequential stdout/stderr deadlock).
                         var outputTask = adb.StandardOutput.ReadToEndAsync();
                         var errorTask = adb.StandardError.ReadToEndAsync();
 
-                        bool exited = adb.WaitForExit(timeoutMs);
+                        bool exited = adb.WaitForExit(effectiveTimeout);
 
                         if (!exited)
                         {
                             try { adb.Kill(); } catch { }
                             adb.WaitForExit(1000);
-                            output = "Connection timed out";
-                            error = "cannot connect: Connection timed out";
-                            Logger.Log($"ADB connect command timed out after {timeoutMs}ms", LogLevel.WARNING);
+                            if (isConnectCommand)
+                            {
+                                output = "Connection timed out";
+                                error = "cannot connect: Connection timed out";
+                            }
+                            else
+                            {
+                                output = "";
+                                error = $"adb command timed out after {effectiveTimeout}ms";
+                            }
+                            Logger.Log($"ADB command timed out after {effectiveTimeout}ms: {command.Trim()}", LogLevel.WARNING);
                         }
                         else
                         {
@@ -144,7 +176,7 @@ namespace AndroidSideloader
                     }
                     else
                     {
-                        // For non-connect commands, read output normally
+                        // Long-running op (transfer/backup/restore/install): read to completion.
                         output = adb.StandardOutput.ReadToEnd();
                         error = adb.StandardError.ReadToEnd();
                     }

--- a/AndroidSideloader.csproj
+++ b/AndroidSideloader.csproj
@@ -313,8 +313,8 @@
     <Compile Include="Properties\ApiKey.cs" />
     <Compile Include="SelectFolder.cs" />
     <Compile Include="TransferQueue.cs" />
-    <Compile Include="TransferWindow.cs">
-      <SubType>Form</SubType>
+    <Compile Include="TransferStrip.cs">
+      <SubType>Component</SubType>
     </Compile>
     <Compile Include="Utilities\SettingsManager.cs" />
     <Compile Include="Utilities\StringUtilities.cs" />

--- a/AndroidSideloader.csproj
+++ b/AndroidSideloader.csproj
@@ -312,6 +312,10 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\ApiKey.cs" />
     <Compile Include="SelectFolder.cs" />
+    <Compile Include="TransferQueue.cs" />
+    <Compile Include="TransferWindow.cs">
+      <SubType>Form</SubType>
+    </Compile>
     <Compile Include="Utilities\SettingsManager.cs" />
     <Compile Include="Utilities\StringUtilities.cs" />
     <Compile Include="Utilities\GeneralUtilities.cs" />

--- a/AndroidSideloader.csproj
+++ b/AndroidSideloader.csproj
@@ -139,6 +139,9 @@
     <Reference Include="AdvancedSharpAdbClient, Version=3.5.15.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\AdvancedSharpAdbClient.3.5.15\lib\net45\AdvancedSharpAdbClient.dll</HintPath>
     </Reference>
+    <Reference Include="BouncyCastle.Cryptography">
+      <HintPath>packages\BouncyCastle.Cryptography.2.4.0\lib\net461\BouncyCastle.Cryptography.dll</HintPath>
+    </Reference>
     <Reference Include="Costura, Version=5.7.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\Costura.Fody.5.7.0\lib\netstandard1.0\Costura.dll</HintPath>
     </Reference>
@@ -151,8 +154,14 @@
     <Reference Include="Microsoft.Web.WebView2.Wpf, Version=1.0.2478.35, Culture=neutral, PublicKeyToken=2a8ab48044d2601e, processorArchitecture=MSIL">
       <HintPath>packages\Microsoft.Web.WebView2.1.0.2478.35\lib\net45\Microsoft.Web.WebView2.Wpf.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces">
+      <HintPath>packages\Microsoft.Bcl.AsyncInterfaces.1.0.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="Renci.SshNet">
+      <HintPath>packages\SSH.NET.2024.2.0\lib\net462\Renci.SshNet.dll</HintPath>
     </Reference>
     <Reference Include="SergeUtils">
       <HintPath>.\SergeUtils.dll</HintPath>
@@ -166,8 +175,29 @@
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.Management" />
     <Reference Include="System.Numerics" />
+    <Reference Include="System.Buffers">
+      <HintPath>packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Formats.Asn1">
+      <HintPath>packages\System.Formats.Asn1.8.0.1\lib\net462\System.Formats.Asn1.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Memory">
+      <HintPath>packages\System.Memory.4.5.5\lib\net461\System.Memory.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Numerics.Vectors">
+      <HintPath>packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe">
+      <HintPath>packages\System.Runtime.CompilerServices.Unsafe.4.5.3\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
     <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions">
+      <HintPath>packages\System.Threading.Tasks.Extensions.4.5.2\lib\netstandard2.0\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ValueTuple">
+      <HintPath>packages\System.ValueTuple.4.5.0\lib\net47\System.ValueTuple.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -184,6 +214,10 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ADB.cs" />
+    <Compile Include="SFTP.cs" />
+    <Compile Include="SftpCredentialsForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
     <Compile Include="AdbCommandForm.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/FlexibleMessageBox.cs
+++ b/FlexibleMessageBox.cs
@@ -843,9 +843,22 @@ namespace JR.Utils.GUI.Forms
             {
                 FlexibleMessageBoxForm flexibleMessageBoxForm = new FlexibleMessageBoxForm
                 {
-                    ShowInTaskbar = false,
+                    // Show in the taskbar and keep the prompt above other windows so it can
+                    // never hide behind another app (e.g. a browser/IDE) and leave the disabled
+                    // main window looking "frozen" while it silently waits for an answer.
+                    ShowInTaskbar = true,
+                    TopMost = true,
                     CaptionText = caption,
                     MessageText = text
+                };
+                flexibleMessageBoxForm.Shown += (s, e) =>
+                {
+                    try
+                    {
+                        flexibleMessageBoxForm.BringToFront();
+                        flexibleMessageBoxForm.Activate();
+                    }
+                    catch { }
                 };
                 flexibleMessageBoxForm.FlexibleMessageBoxFormBindingSource.DataSource = flexibleMessageBoxForm;
                 flexibleMessageBoxForm.titleLabel.Text = caption;

--- a/MainForm.cs
+++ b/MainForm.cs
@@ -7882,10 +7882,22 @@ function onYouTubeIframeAPIReady() {
             {
                 try
                 {
-                    ADB.DeviceID = GetDeviceID();
+                    // Fetch device info OFF the UI thread. These adb shell calls can block for
+                    // tens of seconds if the adb server is mid-restart (e.g. a version-mismatched
+                    // adb elsewhere bounces the daemon); running them here would freeze the whole UI.
+                    var info = await Task.Run(() =>
+                    {
+                        ADB.DeviceID = GetDeviceID();
+                        return new
+                        {
+                            Model = ADB.RunAdbCommandToString("shell getprop ro.product.model").Output.Trim(),
+                            Firmware = ADB.RunAdbCommandToString("shell getprop ro.build.branch").Output.Trim(),
+                            Storage = ADB.RunAdbCommandToString("shell df /data").Output
+                        };
+                    });
 
                     // Get device model
-                    string deviceModel = ADB.RunAdbCommandToString("shell getprop ro.product.model").Output.Trim();
+                    string deviceModel = info.Model;
                     if (string.IsNullOrEmpty(deviceModel))
                     {
                         deviceModel = "No Device Found";
@@ -7893,7 +7905,7 @@ function onYouTubeIframeAPIReady() {
                         bShowStatus = false;
                     }
 
-                    string firmware = ADB.RunAdbCommandToString("shell getprop ro.build.branch").Output.Trim(); // releases-oculus-14.0-v78
+                    string firmware = info.Firmware; // releases-oculus-14.0-v78
                     if (string.IsNullOrEmpty(firmware))
                     {
                         firmware = string.Empty;
@@ -7905,7 +7917,7 @@ function onYouTubeIframeAPIReady() {
                     }
 
                     // Get storage info
-                    string storageOutput = ADB.RunAdbCommandToString("shell df /data").Output;
+                    string storageOutput = info.Storage;
                     string[] lines = storageOutput.Split('\n');
 
                     long totalSpace = 0;

--- a/MainForm.cs
+++ b/MainForm.cs
@@ -52,6 +52,7 @@ namespace AndroidSideloader
 #endif
         private readonly ListViewColumnSorter lvwColumnSorter;
         private static readonly SettingsManager settings = SettingsManager.Instance;
+        private bool _sftpCredsPrompted = false;
         private double _totalQueueSizeMB = 0;
         private double _effectiveQueueSizeMB = 0;
         private Dictionary<string, double> _queueEffectiveSizes = new Dictionary<string, double>(StringComparer.OrdinalIgnoreCase);
@@ -1093,7 +1094,9 @@ namespace AndroidSideloader
         {
             Devices.Clear();
             ADB.DeviceID = GetDeviceID();
-            string output = await Task.Run(() => ADB.RunAdbCommandToString("devices").Output); // Run off UI thread
+            // Resilient: rides through an adb daemon restart so a version-mismatch server
+            // bounce doesn't briefly clear the device and flash "No Device Connected".
+            string output = await Task.Run(() => ADB.GetDevicesResilient().Output); // Run off UI thread
 
             string[] line = output.Split('\n');
             int i = 0;
@@ -1243,9 +1246,42 @@ namespace AndroidSideloader
             }
             else if (Devices.Count > 0 && Devices[0].Length > 1) // Check if Devices list is not empty and the first device has a valid length
             {
-                this.Invoke(() => { Text = "Rookie Sideloader " + Updater.LocalVersion + " | Device Connected: " + Devices[0].Replace("device", String.Empty).Trim(); });
+                string deviceTitle = "Rookie Sideloader " + Updater.LocalVersion + " | Device Connected: " + Devices[0].Replace("device", String.Empty).Trim();
+                this.Invoke(() => { Text = deviceTitle; });
                 DeviceConnected = true;
                 nodeviceonstart = false; // Device connected, clear the flag
+
+                // Detect root + SFTP availability in the background and reflect it in the titlebar
+                _ = Task.Run(async () =>
+                {
+                    await SFTP.DetectAsync(force: true);
+                    try
+                    {
+                        this.Invoke(() => { Text = deviceTitle + SFTP.TitleSuffix; });
+
+                        // A server answered but our credentials didn't work: ask the user
+                        // (once per session) for a password or key file, then retry
+                        if (!SFTP.IsSftpAvailable && SFTP.AuthFailedButServerPresent
+                            && settings.EnableSftpTransfers && !_sftpCredsPrompted)
+                        {
+                            _sftpCredsPrompted = true;
+                            bool retry = false;
+                            this.Invoke(() =>
+                            {
+                                using (SftpCredentialsForm dialog = new SftpCredentialsForm())
+                                {
+                                    retry = dialog.ShowDialog(this) == DialogResult.OK;
+                                }
+                            });
+                            if (retry)
+                            {
+                                await SFTP.DetectAsync(force: true);
+                                this.Invoke(() => { Text = deviceTitle + SFTP.TitleSuffix; });
+                            }
+                        }
+                    }
+                    catch { }
+                });
             }
             else
             {
@@ -10214,7 +10250,7 @@ function onYouTubeIframeAPIReady() {
             // Run a quick device check in background
             try
             {
-                string output = await Task.Run(() => ADB.RunAdbCommandToString("devices", suppressLogging: true).Output);
+                string output = await Task.Run(() => ADB.GetDevicesResilient().Output);
 
                 string[] lines = output.Split('\n');
                 bool hasDeviceNow = false;

--- a/MainForm.cs
+++ b/MainForm.cs
@@ -441,13 +441,15 @@ namespace AndroidSideloader
         {
             _ = Logger.Log("Starting AndroidSideloader Application");
 
-            // Hard kill any lingering adb.exe instances to avoid port/handle conflicts
-            KillAdbProcesses();
-
-            // ADB initialization in background
+            // Reuse an already-running adb server instead of killing it. A hard kill would
+            // tear down any active wireless (adb connect) session and force a reconnect that
+            // often fails silently. start-server is a no-op when a compatible server is already
+            // up, so the existing server - and any connected device, wired or wireless - is
+            // preserved. (Both the bundled adb and any adb in PATH are the same version now, so
+            // there is no version-mismatch bounce to guard against.)
             _adbInitTask = Task.Run(() =>
             {
-                _ = Logger.Log("Attempting to Initialize ADB Server");
+                _ = Logger.Log("Initializing ADB server (reusing existing if already running)");
                 if (File.Exists(Path.Combine(Environment.CurrentDirectory, "platform-tools", "adb.exe")))
                 {
                     _ = ADB.RunAdbCommandToString("start-server");

--- a/MainForm.cs
+++ b/MainForm.cs
@@ -91,6 +91,7 @@ namespace AndroidSideloader
         private const int TILE_SPACING = 10;
         private string freeSpaceText = "";
         private string freeSpaceTextDetailed = "";
+        private TransferStrip _transferStrip;
         private int _questStorageProgress = 0;
         private Color _mirrorPillColor = Color.FromArgb(32, 36, 44);
         private DateTime _mirrorMenuClosedAt = DateTime.MinValue;
@@ -466,6 +467,11 @@ namespace AndroidSideloader
             gamesListView.GridLines = false;
             speedLabel.Text = String.Empty;
             diskLabel.Text = String.Empty;
+
+            // Integrated transfer strip: overlays the bottom of the games list while files
+            // are moving (SFTP / push), themed to match the list, and hides itself when idle.
+            _transferStrip = new TransferStrip(gamesListView.BackColor, gamesListView.ForeColor);
+            _transferStrip.AttachTo(this, gamesListView);
 
             settings.MainDir = Environment.CurrentDirectory;
             settings.Save();

--- a/SFTP.cs
+++ b/SFTP.cs
@@ -414,12 +414,24 @@ namespace AndroidSideloader
                 }
             }
 
-            // How many files to push at once. Each worker gets its own SFTP connection,
-            // since a single SSH.NET client is not safe for concurrent uploads.
-            int degree = settings.SingleThreadMode ? 1 : Math.Max(1, settings.DownloadThreads);
+            // How many files to push at once. Each worker gets its own SFTP connection
+            // (a single SSH.NET client is not safe for concurrent uploads) and pulls the
+            // next file from a shared queue, FileZilla-style, so no more than `degree`
+            // files transfer at any moment regardless of how many OBB files there are.
+            int degree = settings.SingleThreadMode ? 1 : Math.Max(1, settings.SftpThreads);
             degree = Math.Min(degree, Math.Max(1, files.Length));
 
             statusCallback?.Invoke($"Copying: {folderName} (SFTP ×{degree})");
+
+            // Register every file in the transfer window (largest first) and build the work queue.
+            string[] ordered = files.OrderByDescending(f => new FileInfo(f).Length).ToArray();
+            Dictionary<string, TransferItem> transferItems = new Dictionary<string, TransferItem>(StringComparer.Ordinal);
+            foreach (string file in ordered)
+            {
+                transferItems[file] = TransferQueue.Add(Path.GetFileName(file), "SFTP", new FileInfo(file).Length);
+            }
+            System.Collections.Concurrent.ConcurrentQueue<string> workQueue =
+                new System.Collections.Concurrent.ConcurrentQueue<string>(ordered);
 
             // Reports overall progress + throughput; called from every worker thread.
             Action<string> report = (fileName) =>
@@ -453,76 +465,75 @@ namespace AndroidSideloader
                 }
             };
 
-            // Distribute files across workers greedily by size so each connection
-            // carries a roughly equal number of bytes.
-            List<string>[] buckets = new List<string>[degree];
-            long[] bucketBytes = new long[degree];
-            for (int i = 0; i < degree; i++)
-            {
-                buckets[i] = new List<string>();
-            }
-            foreach (string file in files.OrderByDescending(f => new FileInfo(f).Length))
-            {
-                int target = 0;
-                long min = long.MaxValue;
-                for (int i = 0; i < degree; i++)
-                {
-                    if (bucketBytes[i] < min) { min = bucketBytes[i]; target = i; }
-                }
-                buckets[target].Add(file);
-                bucketBytes[target] += new FileInfo(file).Length;
-            }
-
             Exception workerError = null;
-            Parallel.For(0, degree, new ParallelOptions { MaxDegreeOfParallelism = degree }, w =>
+            List<Task> workers = new List<Task>();
+            for (int w = 0; w < degree; w++)
             {
-                if (buckets[w].Count == 0)
+                workers.Add(Task.Run(() =>
                 {
-                    return;
-                }
-                try
-                {
-                    using (SftpClient sftp = new SftpClient(BuildConnectionInfo(Host, Port)))
+                    try
                     {
-                        sftp.Connect();
-                        sftp.BufferSize = TransferBufferSize;
-
-                        foreach (string file in buckets[w])
+                        using (SftpClient sftp = new SftpClient(BuildConnectionInfo(Host, Port)))
                         {
-                            string remoteFilePath = remoteFiles[file];
-                            string fileName = Path.GetFileName(file);
-                            long lastUploaded = 0;
+                            sftp.Connect();
+                            sftp.BufferSize = TransferBufferSize;
 
-                            using (FileStream stream = File.OpenRead(file))
+                            while (workQueue.TryDequeue(out string file))
                             {
-                                sftp.UploadFile(stream, remoteFilePath, true, uploaded =>
-                                {
-                                    long u = (long)uploaded;
-                                    long delta = u - lastUploaded;
-                                    lastUploaded = u;
-                                    if (delta != 0)
-                                    {
-                                        Interlocked.Add(ref transferredBytes, delta);
-                                    }
-                                    report(fileName);
-                                });
-                            }
-                        }
+                                string remoteFilePath = remoteFiles[file];
+                                string fileName = Path.GetFileName(file);
+                                TransferItem item = transferItems[file];
+                                long fileTotal = new FileInfo(file).Length;
+                                DateTime fileStart = DateTime.UtcNow;
+                                long lastUploaded = 0;
 
-                        sftp.Disconnect();
+                                TransferQueue.SetState(item, TransferState.Active);
+
+                                using (FileStream stream = File.OpenRead(file))
+                                {
+                                    sftp.UploadFile(stream, remoteFilePath, true, uploaded =>
+                                    {
+                                        long u = (long)uploaded;
+                                        long delta = u - lastUploaded;
+                                        lastUploaded = u;
+                                        if (delta != 0)
+                                        {
+                                            Interlocked.Add(ref transferredBytes, delta);
+                                        }
+                                        double fe = (DateTime.UtcNow - fileStart).TotalSeconds;
+                                        double fileMBps = fe > 0.1 ? (u / 1048576.0) / fe : 0;
+                                        TransferQueue.Report(item, u, fileMBps);
+                                        report(fileName);
+                                    });
+                                }
+
+                                TransferQueue.Report(item, fileTotal, 0);
+                                TransferQueue.SetState(item, TransferState.Done);
+                            }
+
+                            sftp.Disconnect();
+                        }
                     }
-                }
-                catch (Exception ex)
-                {
-                    lock (progressLock)
+                    catch (Exception ex)
                     {
-                        if (workerError == null) workerError = ex;
+                        lock (progressLock)
+                        {
+                            if (workerError == null) workerError = ex;
+                        }
                     }
-                }
-            });
+                }));
+            }
+            Task.WaitAll(workers.ToArray());
 
             if (workerError != null)
             {
+                foreach (KeyValuePair<string, TransferItem> kv in transferItems)
+                {
+                    if (kv.Value.State != TransferState.Done)
+                    {
+                        TransferQueue.SetState(kv.Value, TransferState.Failed);
+                    }
+                }
                 throw workerError;
             }
 

--- a/SFTP.cs
+++ b/SFTP.cs
@@ -465,76 +465,120 @@ namespace AndroidSideloader
                 }
             };
 
-            Exception workerError = null;
+            int failedCount = 0;
+            Exception lastError = null;
             List<Task> workers = new List<Task>();
             for (int w = 0; w < degree; w++)
             {
                 workers.Add(Task.Run(() =>
                 {
+                    SftpClient sftp = null;
                     try
                     {
-                        using (SftpClient sftp = new SftpClient(BuildConnectionInfo(Host, Port)))
+                        while (workQueue.TryDequeue(out string file))
                         {
-                            sftp.Connect();
-                            sftp.BufferSize = TransferBufferSize;
+                            string remoteFilePath = remoteFiles[file];
+                            string fileName = Path.GetFileName(file);
+                            TransferItem item = transferItems[file];
+                            long fileTotal = new FileInfo(file).Length;
 
-                            while (workQueue.TryDequeue(out string file))
+                            bool ok = false;
+                            Exception fileError = null;
+                            for (int attempt = 0; attempt < 3 && !ok; attempt++)
                             {
-                                string remoteFilePath = remoteFiles[file];
-                                string fileName = Path.GetFileName(file);
-                                TransferItem item = transferItems[file];
-                                long fileTotal = new FileInfo(file).Length;
-                                DateTime fileStart = DateTime.UtcNow;
+                                long fileCounted = 0;
                                 long lastUploaded = 0;
-
-                                TransferQueue.SetState(item, TransferState.Active);
-
-                                using (FileStream stream = File.OpenRead(file))
+                                DateTime fileStart = DateTime.UtcNow;
+                                try
                                 {
-                                    sftp.UploadFile(stream, remoteFilePath, true, uploaded =>
+                                    if (sftp == null || !sftp.IsConnected)
                                     {
-                                        long u = (long)uploaded;
-                                        long delta = u - lastUploaded;
-                                        lastUploaded = u;
-                                        if (delta != 0)
-                                        {
-                                            Interlocked.Add(ref transferredBytes, delta);
-                                        }
-                                        double fe = (DateTime.UtcNow - fileStart).TotalSeconds;
-                                        double fileMBps = fe > 0.1 ? (u / 1048576.0) / fe : 0;
-                                        TransferQueue.Report(item, u, fileMBps);
-                                        report(fileName);
-                                    });
-                                }
+                                        try { sftp?.Dispose(); } catch { }
+                                        sftp = new SftpClient(BuildConnectionInfo(Host, Port));
+                                        // A wedged channel makes each SFTP write request time out and
+                                        // throw instead of blocking UploadFile forever (the softlock).
+                                        sftp.OperationTimeout = TimeSpan.FromSeconds(60);
+                                        sftp.Connect();
+                                        sftp.BufferSize = TransferBufferSize;
+                                    }
 
-                                TransferQueue.Report(item, fileTotal, 0);
-                                TransferQueue.SetState(item, TransferState.Done);
+                                    TransferQueue.SetState(item, TransferState.Active);
+                                    TransferQueue.Report(item, 0, 0);
+
+                                    using (FileStream stream = File.OpenRead(file))
+                                    {
+                                        sftp.UploadFile(stream, remoteFilePath, true, uploaded =>
+                                        {
+                                            long u = (long)uploaded;
+                                            long delta = u - lastUploaded;
+                                            lastUploaded = u;
+                                            if (delta != 0)
+                                            {
+                                                Interlocked.Add(ref transferredBytes, delta);
+                                                fileCounted += delta;
+                                            }
+                                            double fe = (DateTime.UtcNow - fileStart).TotalSeconds;
+                                            double fileMBps = fe > 0.1 ? (u / 1048576.0) / fe : 0;
+                                            TransferQueue.Report(item, u, fileMBps);
+                                            report(fileName);
+                                        });
+                                    }
+
+                                    // Verify the file actually landed at the target path with the
+                                    // exact size. A "completed" upload that isn't really there (or is
+                                    // truncated) is a failure and must be retried, not reported as done.
+                                    var attrs = sftp.GetAttributes(remoteFilePath);
+                                    if (attrs == null || attrs.Size != fileTotal)
+                                    {
+                                        throw new Exception($"verification failed for {fileName}: remote size {(attrs != null ? attrs.Size : -1)} != {fileTotal}");
+                                    }
+
+                                    TransferQueue.Report(item, fileTotal, 0);
+                                    TransferQueue.SetState(item, TransferState.Done);
+                                    ok = true;
+                                }
+                                catch (Exception ex)
+                                {
+                                    fileError = ex;
+                                    // undo this attempt's partial contribution to the overall total
+                                    if (fileCounted != 0) Interlocked.Add(ref transferredBytes, -fileCounted);
+                                    try { sftp?.Dispose(); } catch { }
+                                    sftp = null; // force a fresh connection next attempt
+                                    Logger.Log($"SFTP: '{fileName}' attempt {attempt + 1}/3 failed: {ex.Message}", LogLevel.WARNING);
+                                    if (attempt < 2) System.Threading.Thread.Sleep(500 * (attempt + 1));
+                                }
                             }
 
-                            sftp.Disconnect();
+                            if (!ok)
+                            {
+                                string capturedFile = file;
+                                string capturedRemote = remoteFilePath;
+                                TransferItem capturedItem = item;
+                                capturedItem.Retry = () => RetryUpload(capturedItem, capturedFile, capturedRemote);
+                                TransferQueue.SetState(item, TransferState.Failed);
+                                Interlocked.Increment(ref failedCount);
+                                lock (progressLock) { if (lastError == null) lastError = fileError; }
+                            }
                         }
                     }
                     catch (Exception ex)
                     {
-                        lock (progressLock)
-                        {
-                            if (workerError == null) workerError = ex;
-                        }
+                        lock (progressLock) { if (lastError == null) lastError = ex; }
+                    }
+                    finally
+                    {
+                        try { sftp?.Dispose(); } catch { }
                     }
                 }));
             }
             Task.WaitAll(workers.ToArray());
 
-            if (workerError != null)
+            // If every file failed, the SFTP path is unusable (server gone / auth lost) - throw so
+            // the caller falls back to adb push. If only some failed, leave them in the transfer
+            // strip (marked Failed, each with a Retry action) instead of re-pushing the whole set.
+            if (failedCount >= files.Length && lastError != null)
             {
-                foreach (KeyValuePair<string, TransferItem> kv in transferItems)
-                {
-                    if (kv.Value.State != TransferState.Done)
-                    {
-                        TransferQueue.SetState(kv.Value, TransferState.Failed);
-                    }
-                }
-                throw workerError;
+                throw lastError;
             }
 
             // Make the freshly-written OBB tree readable by the game. adb push goes through
@@ -568,6 +612,85 @@ namespace AndroidSideloader
             double totalSecs = Math.Max(0.1, (DateTime.UtcNow - startTime).TotalSeconds);
             Logger.Log($"SFTP: OBB '{folderName}' transferred ({totalBytes / 1048576.0:0.0} MB in {totalSecs:0.0}s = {(totalBytes / 1048576.0) / totalSecs:0.0} MB/s via {degree}× {User}@{Host}:{Port})");
             return new ProcessOutput($"{gameName}: OBB transfer (SFTP): Success\n", "");
+        }
+
+        // Re-uploads a single OBB file that previously failed. Runs on its own connection and
+        // updates the transfer item in place. Wired to the transfer strip's "Retry" action.
+        public static void RetryUpload(TransferItem item, string localFile, string remoteFilePath)
+        {
+            Task.Run(() =>
+            {
+                try
+                {
+                    if (!File.Exists(localFile))
+                    {
+                        Logger.Log($"SFTP retry: local file missing: {localFile}", LogLevel.ERROR);
+                        TransferQueue.SetState(item, TransferState.Failed);
+                        return;
+                    }
+
+                    TransferQueue.SetState(item, TransferState.Queued);
+                    TransferQueue.Report(item, 0, 0);
+
+                    using (SftpClient sftp = new SftpClient(BuildConnectionInfo(Host, Port)))
+                    {
+                        sftp.OperationTimeout = TimeSpan.FromSeconds(60);
+                        sftp.Connect();
+                        sftp.BufferSize = TransferBufferSize;
+
+                        int slash = remoteFilePath.LastIndexOf('/');
+                        if (slash > 0)
+                        {
+                            EnsureRemoteDirectory(sftp, remoteFilePath.Substring(0, slash), new HashSet<string>());
+                        }
+
+                        long total = new FileInfo(localFile).Length;
+                        DateTime start = DateTime.UtcNow;
+                        using (FileStream stream = File.OpenRead(localFile))
+                        {
+                            sftp.UploadFile(stream, remoteFilePath, true, uploaded =>
+                            {
+                                long u = (long)uploaded;
+                                double e = (DateTime.UtcNow - start).TotalSeconds;
+                                double mbps = e > 0.1 ? (u / 1048576.0) / e : 0;
+                                TransferQueue.Report(item, u, mbps);
+                            });
+                        }
+
+                        var vattrs = sftp.GetAttributes(remoteFilePath);
+                        if (vattrs == null || vattrs.Size != total)
+                        {
+                            throw new Exception($"verification failed: remote size {(vattrs != null ? vattrs.Size : -1)} != {total}");
+                        }
+
+                        TransferQueue.Report(item, total, 0);
+                        TransferQueue.SetState(item, TransferState.Done);
+                        sftp.Disconnect();
+                    }
+
+                    // best-effort perms fix on the retried file
+                    try
+                    {
+                        string q = "'" + remoteFilePath.Replace("'", "'\\''") + "'";
+                        using (SshClient ssh = new SshClient(BuildConnectionInfo(Host, Port)))
+                        {
+                            ssh.Connect();
+                            using (SshCommand cmd = ssh.CreateCommand($"chmod 0777 {q} 2>/dev/null; restorecon {q} 2>/dev/null; true"))
+                            {
+                                cmd.CommandTimeout = TimeSpan.FromSeconds(15);
+                                cmd.Execute();
+                            }
+                            ssh.Disconnect();
+                        }
+                    }
+                    catch { }
+                }
+                catch (Exception ex)
+                {
+                    Logger.Log($"SFTP retry failed for {Path.GetFileName(localFile)}: {ex.Message}", LogLevel.ERROR);
+                    TransferQueue.SetState(item, TransferState.Failed);
+                }
+            });
         }
 
         private static void EnsureRemoteDirectory(SftpClient sftp, string remoteDir, HashSet<string> created)

--- a/SFTP.cs
+++ b/SFTP.cs
@@ -526,6 +526,31 @@ namespace AndroidSideloader
                 throw workerError;
             }
 
+            // Make the freshly-written OBB tree readable by the game. adb push goes through
+            // the adb daemon which lands app-readable perms; an sshd running as root can
+            // instead write root-owned/restrictive files. On FUSE-emulated storage these
+            // calls are effectively no-ops (perms/SELinux labels are synthesized), but where
+            // the sshd writes through to a real filesystem this is what lets the app open its
+            // OBB. Best-effort — failures are ignored.
+            try
+            {
+                using (SshClient ssh = new SshClient(BuildConnectionInfo(Host, Port)))
+                {
+                    ssh.Connect();
+                    using (SshCommand cmd = ssh.CreateCommand(
+                        $"chmod -R 0777 {quotedRemotePath} 2>/dev/null; restorecon -R {quotedRemotePath} 2>/dev/null; true"))
+                    {
+                        cmd.CommandTimeout = TimeSpan.FromSeconds(30);
+                        cmd.Execute();
+                    }
+                    ssh.Disconnect();
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"SFTP: post-transfer chmod/restorecon skipped: {ex.Message}", LogLevel.WARNING);
+            }
+
             progressCallback?.Invoke(100, null);
             statusCallback?.Invoke("");
 

--- a/SFTP.cs
+++ b/SFTP.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Net.Sockets;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace AndroidSideloader
@@ -356,17 +357,19 @@ namespace AndroidSideloader
 
             string[] files = Directory.GetFiles(localPath, "*", SearchOption.AllDirectories);
             long totalBytes = files.Sum(f => new FileInfo(f).Length);
-            long transferredBytes = 0;
+            long transferredBytes = 0; // shared across worker threads (Interlocked)
 
+            DateTime startTime = DateTime.UtcNow;
             DateTime lastProgressUpdate = DateTime.MinValue;
             float lastReportedPercent = -1;
             const int ThrottleMs = 100;
             EtaEstimator eta = new EtaEstimator(alpha: 0.10, reanchorThreshold: 0.20);
+            object progressLock = new object();
 
+            // Recreate the OBB folder fresh, matching the adb push behaviour
             using (SshClient ssh = new SshClient(BuildConnectionInfo(Host, Port)))
             {
                 ssh.Connect();
-                // Recreate the OBB folder fresh, matching the adb push behaviour
                 using (SshCommand cmd = ssh.CreateCommand($"rm -rf {quotedRemotePath} && mkdir -p {quotedRemotePath}"))
                 {
                     cmd.CommandTimeout = TimeSpan.FromSeconds(60);
@@ -379,68 +382,155 @@ namespace AndroidSideloader
                 ssh.Disconnect();
             }
 
-            using (SftpClient sftp = new SftpClient(BuildConnectionInfo(Host, Port)))
+            // Map every local file to its remote path, and pre-create all remote
+            // subdirectories up front on a single connection. Doing this before the
+            // parallel phase avoids races on directory creation between workers.
+            var remoteFiles = new Dictionary<string, string>(files.Length, StringComparer.Ordinal);
+            var remoteDirs = new HashSet<string>(StringComparer.Ordinal);
+            foreach (string file in files)
             {
-                sftp.Connect();
-                sftp.BufferSize = TransferBufferSize;
-
-                HashSet<string> createdDirs = new HashSet<string> { remotePath };
-                statusCallback?.Invoke($"Copying: {folderName} (SFTP)");
-
-                foreach (string file in files)
+                string relativePath = file.Substring(localPath.Length)
+                                          .TrimStart('\\', '/')
+                                          .Replace('\\', '/');
+                string remoteFilePath = $"{remotePath}/{relativePath}";
+                remoteFiles[file] = remoteFilePath;
+                int slash = remoteFilePath.LastIndexOf('/');
+                if (slash > 0)
                 {
-                    string relativePath = file.Substring(localPath.Length)
-                                              .TrimStart('\\', '/')
-                                              .Replace('\\', '/');
-                    string remoteFilePath = $"{remotePath}/{relativePath}";
-                    string fileName = Path.GetFileName(file);
-
-                    string remoteDir = remoteFilePath.Substring(0, remoteFilePath.LastIndexOf('/'));
-                    EnsureRemoteDirectory(sftp, remoteDir, createdDirs);
-
-                    long fileSize = new FileInfo(file).Length;
-                    long baseTransferred = transferredBytes;
-
-                    using (FileStream stream = File.OpenRead(file))
-                    {
-                        sftp.UploadFile(stream, remoteFilePath, true, uploaded =>
-                        {
-                            long totalProgressBytes = baseTransferred + (long)uploaded;
-
-                            float overallPercent = totalBytes > 0
-                                ? (float)(totalProgressBytes * 100.0 / totalBytes)
-                                : 0f;
-                            overallPercent = Math.Max(0, Math.Min(100, overallPercent));
-
-                            if (totalBytes > 0 && totalProgressBytes > 0 && overallPercent < 100)
-                            {
-                                eta.Update(totalUnits: totalBytes, doneUnits: totalProgressBytes);
-                            }
-                            TimeSpan? displayEta = eta.GetDisplayEta();
-
-                            DateTime now = DateTime.UtcNow;
-                            bool shouldUpdate = (now - lastProgressUpdate).TotalMilliseconds >= ThrottleMs
-                                                || Math.Abs(overallPercent - lastReportedPercent) >= 0.1f;
-                            if (shouldUpdate)
-                            {
-                                lastProgressUpdate = now;
-                                lastReportedPercent = overallPercent;
-                                progressCallback?.Invoke(overallPercent, displayEta);
-                                statusCallback?.Invoke($"{fileName} · SFTP");
-                            }
-                        });
-                    }
-
-                    transferredBytes += fileSize;
+                    remoteDirs.Add(remoteFilePath.Substring(0, slash));
                 }
+            }
+            if (remoteDirs.Any(d => d != remotePath))
+            {
+                using (SftpClient dirClient = new SftpClient(BuildConnectionInfo(Host, Port)))
+                {
+                    dirClient.Connect();
+                    HashSet<string> created = new HashSet<string> { remotePath };
+                    foreach (string dir in remoteDirs)
+                    {
+                        EnsureRemoteDirectory(dirClient, dir, created);
+                    }
+                    dirClient.Disconnect();
+                }
+            }
 
-                sftp.Disconnect();
+            // How many files to push at once. Each worker gets its own SFTP connection,
+            // since a single SSH.NET client is not safe for concurrent uploads.
+            int degree = settings.SingleThreadMode ? 1 : Math.Max(1, settings.DownloadThreads);
+            degree = Math.Min(degree, Math.Max(1, files.Length));
+
+            statusCallback?.Invoke($"Copying: {folderName} (SFTP ×{degree})");
+
+            // Reports overall progress + throughput; called from every worker thread.
+            Action<string> report = (fileName) =>
+            {
+                DateTime now = DateTime.UtcNow;
+                long done = Interlocked.Read(ref transferredBytes);
+                lock (progressLock)
+                {
+                    float overallPercent = totalBytes > 0
+                        ? (float)(done * 100.0 / totalBytes)
+                        : 0f;
+                    overallPercent = Math.Max(0, Math.Min(100, overallPercent));
+
+                    if (totalBytes > 0 && done > 0 && overallPercent < 100)
+                    {
+                        eta.Update(totalUnits: totalBytes, doneUnits: done);
+                    }
+                    TimeSpan? displayEta = eta.GetDisplayEta();
+
+                    bool shouldUpdate = (now - lastProgressUpdate).TotalMilliseconds >= ThrottleMs
+                                        || Math.Abs(overallPercent - lastReportedPercent) >= 0.1f;
+                    if (shouldUpdate)
+                    {
+                        lastProgressUpdate = now;
+                        lastReportedPercent = overallPercent;
+                        double elapsed = (now - startTime).TotalSeconds;
+                        double speedMBps = elapsed > 0.1 ? (done / 1048576.0) / elapsed : 0;
+                        progressCallback?.Invoke(overallPercent, displayEta);
+                        statusCallback?.Invoke($"{fileName} · {speedMBps:0.0} MB/s · SFTP");
+                    }
+                }
+            };
+
+            // Distribute files across workers greedily by size so each connection
+            // carries a roughly equal number of bytes.
+            List<string>[] buckets = new List<string>[degree];
+            long[] bucketBytes = new long[degree];
+            for (int i = 0; i < degree; i++)
+            {
+                buckets[i] = new List<string>();
+            }
+            foreach (string file in files.OrderByDescending(f => new FileInfo(f).Length))
+            {
+                int target = 0;
+                long min = long.MaxValue;
+                for (int i = 0; i < degree; i++)
+                {
+                    if (bucketBytes[i] < min) { min = bucketBytes[i]; target = i; }
+                }
+                buckets[target].Add(file);
+                bucketBytes[target] += new FileInfo(file).Length;
+            }
+
+            Exception workerError = null;
+            Parallel.For(0, degree, new ParallelOptions { MaxDegreeOfParallelism = degree }, w =>
+            {
+                if (buckets[w].Count == 0)
+                {
+                    return;
+                }
+                try
+                {
+                    using (SftpClient sftp = new SftpClient(BuildConnectionInfo(Host, Port)))
+                    {
+                        sftp.Connect();
+                        sftp.BufferSize = TransferBufferSize;
+
+                        foreach (string file in buckets[w])
+                        {
+                            string remoteFilePath = remoteFiles[file];
+                            string fileName = Path.GetFileName(file);
+                            long lastUploaded = 0;
+
+                            using (FileStream stream = File.OpenRead(file))
+                            {
+                                sftp.UploadFile(stream, remoteFilePath, true, uploaded =>
+                                {
+                                    long u = (long)uploaded;
+                                    long delta = u - lastUploaded;
+                                    lastUploaded = u;
+                                    if (delta != 0)
+                                    {
+                                        Interlocked.Add(ref transferredBytes, delta);
+                                    }
+                                    report(fileName);
+                                });
+                            }
+                        }
+
+                        sftp.Disconnect();
+                    }
+                }
+                catch (Exception ex)
+                {
+                    lock (progressLock)
+                    {
+                        if (workerError == null) workerError = ex;
+                    }
+                }
+            });
+
+            if (workerError != null)
+            {
+                throw workerError;
             }
 
             progressCallback?.Invoke(100, null);
             statusCallback?.Invoke("");
 
-            Logger.Log($"SFTP: OBB '{folderName}' transferred ({totalBytes / 1048576.0:0.0} MB via {User}@{Host}:{Port})");
+            double totalSecs = Math.Max(0.1, (DateTime.UtcNow - startTime).TotalSeconds);
+            Logger.Log($"SFTP: OBB '{folderName}' transferred ({totalBytes / 1048576.0:0.0} MB in {totalSecs:0.0}s = {(totalBytes / 1048576.0) / totalSecs:0.0} MB/s via {degree}× {User}@{Host}:{Port})");
             return new ProcessOutput($"{gameName}: OBB transfer (SFTP): Success\n", "");
         }
 

--- a/SFTP.cs
+++ b/SFTP.cs
@@ -1,0 +1,471 @@
+using AndroidSideloader.Utilities;
+using Renci.SshNet;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Sockets;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace AndroidSideloader
+{
+    // SFTP fast path for large transfers (OBBs) to rooted headsets running an SSH server.
+    // adb push tops out well below what the Quest's WiFi/USB link can do; a direct SFTP
+    // session to an on-device sshd is typically several times faster for multi-GB OBBs.
+    // Everything here degrades gracefully: if no SSH server is reachable, transfers fall
+    // back to the regular adb push path automatically.
+    internal static class SFTP
+    {
+        private static readonly SettingsManager settings = SettingsManager.Instance;
+
+        private static readonly object _detectLock = new object();
+        private static Task<bool> _detectionTask;
+        private static string _detectedDeviceId;
+
+        // Results of the last detection run
+        public static bool RootChecked { get; private set; }
+        public static bool IsRootAvailable { get; private set; }
+        public static bool IsSftpAvailable { get; private set; }
+        // An SSH server answered but no configured credential worked - the UI uses
+        // this to ask the user for a key file or password
+        public static bool AuthFailedButServerPresent { get; private set; }
+        public static string Host { get; private set; }
+        public static int Port { get; private set; }
+        public static string User { get; private set; }
+
+        private static readonly int[] DefaultPorts = { 22, 8022, 2222 };
+        // /storage/emulated/0 is the canonical path; /sdcard is a symlink that some
+        // sshd mount namespaces cannot resolve, so it is only the fallback.
+        private static readonly string[] ObbRootCandidates =
+        {
+            "/storage/emulated/0/Android/obb",
+            "/sdcard/Android/obb"
+        };
+        private static string _obbRoot = ObbRootCandidates[0];
+        // Upper bound only: SSH.NET clamps each write to the server's negotiated max
+        private const uint TransferBufferSize = 1048576;
+
+        // Short status for the titlebar, e.g. " | Root ✓ | SFTP ✓ (root@192.168.1.35:22)"
+        public static string TitleSuffix
+        {
+            get
+            {
+                string suffix = "";
+                if (RootChecked)
+                {
+                    suffix += IsRootAvailable ? " | Root ✓" : " | Root ✗";
+                    suffix += IsSftpAvailable ? $" | SFTP ✓ ({User}@{Host}:{Port})" : " | SFTP ✗";
+                }
+                return suffix;
+            }
+        }
+
+        public static void InvalidateCache()
+        {
+            lock (_detectLock)
+            {
+                _detectionTask = null;
+                _detectedDeviceId = null;
+                RootChecked = false;
+                IsRootAvailable = false;
+                IsSftpAvailable = false;
+            }
+        }
+
+        // Runs root + SFTP detection once per connected device; safe to call repeatedly.
+        public static Task<bool> DetectAsync(bool force = false)
+        {
+            lock (_detectLock)
+            {
+                if (force || _detectionTask == null || _detectedDeviceId != ADB.DeviceID)
+                {
+                    _detectedDeviceId = ADB.DeviceID;
+                    _detectionTask = Task.Run(() => Detect());
+                }
+                return _detectionTask;
+            }
+        }
+
+        private static bool Detect()
+        {
+            try
+            {
+                IsRootAvailable = DetectRoot();
+                RootChecked = true;
+                Logger.Log($"SFTP: root access {(IsRootAvailable ? "detected (su grants uid=0)" : "not detected")}");
+
+                IsSftpAvailable = DetectSftp();
+                Logger.Log(IsSftpAvailable
+                    ? $"SFTP: server available at {User}@{Host}:{Port} - OBB transfers will use SFTP"
+                    : "SFTP: no usable server found - OBB transfers will use adb push");
+                return IsSftpAvailable;
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"SFTP: detection failed: {ex.Message}", LogLevel.ERROR);
+                return false;
+            }
+        }
+
+        // 'timeout' guards against Magisk/KernelSU showing a grant prompt and blocking forever
+        private static bool DetectRoot()
+        {
+            ProcessOutput result = ADB.RunAdbCommandToString("shell \"timeout 3 su -c id\"", true);
+            if (result.Output.Contains("uid=0"))
+            {
+                return true;
+            }
+
+            ProcessOutput which = ADB.RunAdbCommandToString("shell which su", true);
+            if (!string.IsNullOrWhiteSpace(which.Output))
+            {
+                Logger.Log("SFTP: su binary present but a root shell was not granted", LogLevel.WARNING);
+            }
+            return false;
+        }
+
+        // Resolves the headset's IP: explicit setting > wireless ADB serial > ip route > wlan0
+        public static string GetDeviceIp()
+        {
+            if (!string.IsNullOrEmpty(settings.SftpHost))
+            {
+                return settings.SftpHost;
+            }
+
+            string serial = ADB.DeviceID;
+            if (!string.IsNullOrEmpty(serial))
+            {
+                Match m = Regex.Match(serial, @"^(\d{1,3}(?:\.\d{1,3}){3}):\d+$");
+                if (m.Success)
+                {
+                    return m.Groups[1].Value;
+                }
+            }
+
+            ProcessOutput route = ADB.RunAdbCommandToString("shell ip route", true);
+            Match src = Regex.Match(route.Output, @"\bsrc\s+(\d{1,3}(?:\.\d{1,3}){3})");
+            if (src.Success)
+            {
+                return src.Groups[1].Value;
+            }
+
+            ProcessOutput wlan = ADB.RunAdbCommandToString("shell ip -f inet addr show wlan0", true);
+            Match inet = Regex.Match(wlan.Output, @"inet\s+(\d{1,3}(?:\.\d{1,3}){3})");
+            return inet.Success ? inet.Groups[1].Value : null;
+        }
+
+        private static bool DetectSftp()
+        {
+            AuthFailedButServerPresent = false;
+
+            string host = GetDeviceIp();
+            if (string.IsNullOrEmpty(host))
+            {
+                Logger.Log("SFTP: could not determine headset IP address", LogLevel.WARNING);
+                return false;
+            }
+
+            bool sawServer = false;
+            int[] ports = settings.SftpPort > 0 ? new[] { settings.SftpPort } : DefaultPorts;
+            foreach (int port in ports)
+            {
+                if (!HasSshBanner(host, port))
+                {
+                    continue;
+                }
+                sawServer = true;
+
+                if (TryAuthenticate(host, port))
+                {
+                    Host = host;
+                    Port = port;
+                    return true;
+                }
+            }
+
+            AuthFailedButServerPresent = sawServer;
+            return false;
+        }
+
+        // SSH servers send their version banner immediately after accept, so a quick
+        // connect+read cheaply filters out closed ports and non-SSH services.
+        private static bool HasSshBanner(string host, int port)
+        {
+            try
+            {
+                using (TcpClient tcp = new TcpClient())
+                {
+                    IAsyncResult ar = tcp.BeginConnect(host, port, null, null);
+                    if (!ar.AsyncWaitHandle.WaitOne(1000) )
+                    {
+                        return false;
+                    }
+                    tcp.EndConnect(ar);
+
+                    NetworkStream stream = tcp.GetStream();
+                    stream.ReadTimeout = 2000;
+                    byte[] buffer = new byte[255];
+                    int read = stream.Read(buffer, 0, buffer.Length);
+                    bool isSsh = read >= 4 && System.Text.Encoding.ASCII.GetString(buffer, 0, read).StartsWith("SSH-");
+                    if (isSsh)
+                    {
+                        Logger.Log($"SFTP: SSH server found on {host}:{port}");
+                    }
+                    return isSsh;
+                }
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        private static IEnumerable<string> CandidateKeyPaths()
+        {
+            if (!string.IsNullOrEmpty(settings.SftpPrivateKeyPath))
+            {
+                yield return settings.SftpPrivateKeyPath;
+            }
+
+            string sshDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".ssh");
+            yield return Path.Combine(sshDir, "quest_root");
+            yield return Path.Combine(sshDir, "id_ed25519");
+            yield return Path.Combine(sshDir, "id_rsa");
+        }
+
+        private static ConnectionInfo BuildConnectionInfo(string host, int port)
+        {
+            string user = string.IsNullOrEmpty(settings.SftpUsername) ? "root" : settings.SftpUsername;
+
+            List<AuthenticationMethod> methods = new List<AuthenticationMethod>();
+            List<PrivateKeyFile> keys = new List<PrivateKeyFile>();
+            foreach (string keyPath in CandidateKeyPaths().Distinct().Where(File.Exists))
+            {
+                try
+                {
+                    keys.Add(new PrivateKeyFile(keyPath));
+                }
+                catch (Exception ex)
+                {
+                    Logger.Log($"SFTP: could not load key '{keyPath}': {ex.Message}", LogLevel.WARNING);
+                }
+            }
+            if (keys.Count > 0)
+            {
+                methods.Add(new PrivateKeyAuthenticationMethod(user, keys.ToArray()));
+            }
+            if (!string.IsNullOrEmpty(settings.SftpPassword))
+            {
+                methods.Add(new PasswordAuthenticationMethod(user, settings.SftpPassword));
+
+                // Many sshd builds are configured for keyboard-interactive instead of
+                // plain password auth; answer every prompt with the stored password
+                KeyboardInteractiveAuthenticationMethod interactive = new KeyboardInteractiveAuthenticationMethod(user);
+                interactive.AuthenticationPrompt += (sender, e) =>
+                {
+                    foreach (Renci.SshNet.Common.AuthenticationPrompt prompt in e.Prompts)
+                    {
+                        prompt.Response = settings.SftpPassword;
+                    }
+                };
+                methods.Add(interactive);
+            }
+            // Some rootful sshd builds accept root with no credentials at all
+            methods.Add(new NoneAuthenticationMethod(user));
+
+            ConnectionInfo info = new ConnectionInfo(host, port, user, methods.ToArray())
+            {
+                Timeout = TimeSpan.FromSeconds(6)
+            };
+            User = user;
+            return info;
+        }
+
+        private static bool TryAuthenticate(string host, int port)
+        {
+            try
+            {
+                using (SftpClient sftp = new SftpClient(BuildConnectionInfo(host, port)))
+                {
+                    sftp.Connect();
+                    string obbRoot = ObbRootCandidates.FirstOrDefault(sftp.Exists);
+                    sftp.Disconnect();
+
+                    if (obbRoot == null)
+                    {
+                        // An sshd whose mount namespace lacks the shared storage would
+                        // silently strand files where no game can read them, so treat as unusable
+                        Logger.Log($"SFTP: authenticated on {host}:{port} but {ObbRootCandidates[0]} is not visible - ignoring this server", LogLevel.WARNING);
+                        return false;
+                    }
+                    _obbRoot = obbRoot;
+                    return true;
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"SFTP: authentication to {host}:{port} failed: {ex.Message}", LogLevel.WARNING);
+                return false;
+            }
+        }
+
+        // Attempts the OBB copy over SFTP. Returns null when SFTP is disabled, undetected
+        // or fails, which tells the caller to fall back to the adb push path.
+        public static async Task<ProcessOutput> TryCopyObbWithProgressAsync(
+            string localPath,
+            Action<float, TimeSpan?> progressCallback = null,
+            Action<string> statusCallback = null,
+            string gameName = "")
+        {
+            if (!settings.EnableSftpTransfers)
+            {
+                return null;
+            }
+
+            bool available = await DetectAsync();
+            if (!available)
+            {
+                return null;
+            }
+
+            try
+            {
+                return await Task.Run(() => CopyObbCore(localPath, progressCallback, statusCallback, gameName));
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"SFTP: OBB transfer failed, falling back to adb push: {ex.Message}", LogLevel.ERROR);
+                InvalidateCache();
+                return null;
+            }
+        }
+
+        private static ProcessOutput CopyObbCore(
+            string localPath,
+            Action<float, TimeSpan?> progressCallback,
+            Action<string> statusCallback,
+            string gameName)
+        {
+            string folderName = Path.GetFileName(localPath);
+            string remotePath = $"{_obbRoot}/{folderName}";
+            string quotedRemotePath = "'" + remotePath.Replace("'", "'\\''") + "'";
+
+            statusCallback?.Invoke($"Preparing: {folderName} (SFTP)");
+            progressCallback?.Invoke(0, null);
+
+            string[] files = Directory.GetFiles(localPath, "*", SearchOption.AllDirectories);
+            long totalBytes = files.Sum(f => new FileInfo(f).Length);
+            long transferredBytes = 0;
+
+            DateTime lastProgressUpdate = DateTime.MinValue;
+            float lastReportedPercent = -1;
+            const int ThrottleMs = 100;
+            EtaEstimator eta = new EtaEstimator(alpha: 0.10, reanchorThreshold: 0.20);
+
+            using (SshClient ssh = new SshClient(BuildConnectionInfo(Host, Port)))
+            {
+                ssh.Connect();
+                // Recreate the OBB folder fresh, matching the adb push behaviour
+                using (SshCommand cmd = ssh.CreateCommand($"rm -rf {quotedRemotePath} && mkdir -p {quotedRemotePath}"))
+                {
+                    cmd.CommandTimeout = TimeSpan.FromSeconds(60);
+                    cmd.Execute();
+                    if (cmd.ExitStatus != 0)
+                    {
+                        throw new Exception($"remote mkdir failed: {cmd.Error}");
+                    }
+                }
+                ssh.Disconnect();
+            }
+
+            using (SftpClient sftp = new SftpClient(BuildConnectionInfo(Host, Port)))
+            {
+                sftp.Connect();
+                sftp.BufferSize = TransferBufferSize;
+
+                HashSet<string> createdDirs = new HashSet<string> { remotePath };
+                statusCallback?.Invoke($"Copying: {folderName} (SFTP)");
+
+                foreach (string file in files)
+                {
+                    string relativePath = file.Substring(localPath.Length)
+                                              .TrimStart('\\', '/')
+                                              .Replace('\\', '/');
+                    string remoteFilePath = $"{remotePath}/{relativePath}";
+                    string fileName = Path.GetFileName(file);
+
+                    string remoteDir = remoteFilePath.Substring(0, remoteFilePath.LastIndexOf('/'));
+                    EnsureRemoteDirectory(sftp, remoteDir, createdDirs);
+
+                    long fileSize = new FileInfo(file).Length;
+                    long baseTransferred = transferredBytes;
+
+                    using (FileStream stream = File.OpenRead(file))
+                    {
+                        sftp.UploadFile(stream, remoteFilePath, true, uploaded =>
+                        {
+                            long totalProgressBytes = baseTransferred + (long)uploaded;
+
+                            float overallPercent = totalBytes > 0
+                                ? (float)(totalProgressBytes * 100.0 / totalBytes)
+                                : 0f;
+                            overallPercent = Math.Max(0, Math.Min(100, overallPercent));
+
+                            if (totalBytes > 0 && totalProgressBytes > 0 && overallPercent < 100)
+                            {
+                                eta.Update(totalUnits: totalBytes, doneUnits: totalProgressBytes);
+                            }
+                            TimeSpan? displayEta = eta.GetDisplayEta();
+
+                            DateTime now = DateTime.UtcNow;
+                            bool shouldUpdate = (now - lastProgressUpdate).TotalMilliseconds >= ThrottleMs
+                                                || Math.Abs(overallPercent - lastReportedPercent) >= 0.1f;
+                            if (shouldUpdate)
+                            {
+                                lastProgressUpdate = now;
+                                lastReportedPercent = overallPercent;
+                                progressCallback?.Invoke(overallPercent, displayEta);
+                                statusCallback?.Invoke($"{fileName} · SFTP");
+                            }
+                        });
+                    }
+
+                    transferredBytes += fileSize;
+                }
+
+                sftp.Disconnect();
+            }
+
+            progressCallback?.Invoke(100, null);
+            statusCallback?.Invoke("");
+
+            Logger.Log($"SFTP: OBB '{folderName}' transferred ({totalBytes / 1048576.0:0.0} MB via {User}@{Host}:{Port})");
+            return new ProcessOutput($"{gameName}: OBB transfer (SFTP): Success\n", "");
+        }
+
+        private static void EnsureRemoteDirectory(SftpClient sftp, string remoteDir, HashSet<string> created)
+        {
+            if (created.Contains(remoteDir))
+            {
+                return;
+            }
+
+            string[] segments = remoteDir.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+            string current = "";
+            foreach (string segment in segments)
+            {
+                current += "/" + segment;
+                if (created.Contains(current))
+                {
+                    continue;
+                }
+                if (!sftp.Exists(current))
+                {
+                    sftp.CreateDirectory(current);
+                }
+                created.Add(current);
+            }
+        }
+    }
+}

--- a/SftpCredentialsForm.cs
+++ b/SftpCredentialsForm.cs
@@ -1,0 +1,186 @@
+using AndroidSideloader.Utilities;
+using System;
+using System.Drawing;
+using System.IO;
+using System.Windows.Forms;
+
+namespace AndroidSideloader
+{
+    // Shown when an SSH server is detected on the headset but none of the stored
+    // credentials work. Lets the user supply a username plus a password and/or a
+    // private key file, which are persisted to settings for future sessions.
+    public class SftpCredentialsForm : Form
+    {
+        private static readonly SettingsManager settings = SettingsManager.Instance;
+
+        private TextBox usernameBox;
+        private TextBox passwordBox;
+        private TextBox keyPathBox;
+        private CheckBox disableCheck;
+
+        public SftpCredentialsForm()
+        {
+            InitializeLayout();
+        }
+
+        private void InitializeLayout()
+        {
+            Text = "SFTP Fast Transfers - Credentials";
+            FormBorderStyle = FormBorderStyle.FixedDialog;
+            MaximizeBox = false;
+            MinimizeBox = false;
+            StartPosition = FormStartPosition.CenterParent;
+            ClientSize = new Size(460, 300);
+            BackColor = settings.BackColor;
+            ForeColor = settings.FontColor;
+            Font = settings.FontStyle;
+
+            Label header = new Label
+            {
+                Text = "An SSH server was found on your headset, but Rookie could not log in.\n" +
+                       "Enter its credentials to enable fast OBB transfers over SFTP.",
+                Location = new Point(12, 10),
+                Size = new Size(436, 50),
+                ForeColor = settings.FontColor
+            };
+            Controls.Add(header);
+
+            Controls.Add(MakeLabel("Username:", 12, 70));
+            usernameBox = MakeTextBox(130, 67, 200);
+            usernameBox.Text = string.IsNullOrEmpty(settings.SftpUsername) ? "root" : settings.SftpUsername;
+            Controls.Add(usernameBox);
+
+            Controls.Add(MakeLabel("Password:", 12, 110));
+            passwordBox = MakeTextBox(130, 107, 200);
+            passwordBox.UseSystemPasswordChar = true;
+            passwordBox.Text = settings.SftpPassword;
+            Controls.Add(passwordBox);
+
+            Controls.Add(MakeLabel("Key file:", 12, 150));
+            keyPathBox = MakeTextBox(130, 147, 240);
+            keyPathBox.Text = settings.SftpPrivateKeyPath;
+            Controls.Add(keyPathBox);
+
+            Button browseButton = new Button
+            {
+                Text = "...",
+                Location = new Point(378, 145),
+                Size = new Size(40, 28),
+                BackColor = settings.ButtonColor,
+                ForeColor = settings.FontColor,
+                FlatStyle = FlatStyle.Flat
+            };
+            browseButton.Click += (s, e) =>
+            {
+                using (OpenFileDialog dialog = new OpenFileDialog())
+                {
+                    dialog.Title = "Select SSH private key";
+                    string sshDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".ssh");
+                    if (Directory.Exists(sshDir))
+                    {
+                        dialog.InitialDirectory = sshDir;
+                    }
+                    dialog.Filter = "All files (*.*)|*.*";
+                    if (dialog.ShowDialog(this) == DialogResult.OK)
+                    {
+                        keyPathBox.Text = dialog.FileName;
+                    }
+                }
+            };
+            Controls.Add(browseButton);
+
+            disableCheck = new CheckBox
+            {
+                Text = "Don't ask again (disable SFTP fast transfers)",
+                Location = new Point(15, 195),
+                Size = new Size(420, 24),
+                ForeColor = settings.FontColor
+            };
+            Controls.Add(disableCheck);
+
+            Button okButton = new Button
+            {
+                Text = "Save && Retry",
+                Location = new Point(130, 240),
+                Size = new Size(120, 34),
+                BackColor = settings.ButtonColor,
+                ForeColor = settings.FontColor,
+                FlatStyle = FlatStyle.Flat
+            };
+            okButton.Click += OkClicked;
+            Controls.Add(okButton);
+
+            Button cancelButton = new Button
+            {
+                Text = "Cancel",
+                Location = new Point(260, 240),
+                Size = new Size(100, 34),
+                BackColor = settings.ButtonColor,
+                ForeColor = settings.FontColor,
+                FlatStyle = FlatStyle.Flat,
+                DialogResult = DialogResult.Cancel
+            };
+            Controls.Add(cancelButton);
+
+            AcceptButton = okButton;
+            CancelButton = cancelButton;
+        }
+
+        private Label MakeLabel(string text, int x, int y)
+        {
+            return new Label
+            {
+                Text = text,
+                Location = new Point(x, y),
+                Size = new Size(112, 24),
+                ForeColor = settings.FontColor
+            };
+        }
+
+        private TextBox MakeTextBox(int x, int y, int width)
+        {
+            return new TextBox
+            {
+                Location = new Point(x, y),
+                Size = new Size(width, 28),
+                BackColor = settings.TextBoxColor,
+                ForeColor = settings.FontColor,
+                BorderStyle = BorderStyle.FixedSingle
+            };
+        }
+
+        private void OkClicked(object sender, EventArgs e)
+        {
+            if (disableCheck.Checked)
+            {
+                settings.EnableSftpTransfers = false;
+                settings.Save();
+                DialogResult = DialogResult.Cancel;
+                Close();
+                return;
+            }
+
+            string keyPath = keyPathBox.Text.Trim();
+            if (!string.IsNullOrEmpty(keyPath) && !File.Exists(keyPath))
+            {
+                _ = MessageBox.Show(this, "The selected key file does not exist.", "SFTP",
+                    MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                return;
+            }
+            if (string.IsNullOrEmpty(keyPath) && string.IsNullOrEmpty(passwordBox.Text))
+            {
+                _ = MessageBox.Show(this, "Enter a password or select a private key file.", "SFTP",
+                    MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                return;
+            }
+
+            settings.SftpUsername = usernameBox.Text.Trim();
+            settings.SftpPassword = passwordBox.Text;
+            settings.SftpPrivateKeyPath = keyPath;
+            settings.Save();
+
+            DialogResult = DialogResult.OK;
+            Close();
+        }
+    }
+}

--- a/TransferQueue.cs
+++ b/TransferQueue.cs
@@ -5,7 +5,7 @@ namespace AndroidSideloader
 {
     public enum TransferState { Queued, Active, Done, Failed }
 
-    // A single file transfer surfaced in the TransferWindow.
+    // A single file transfer surfaced in the integrated transfer strip.
     public class TransferItem
     {
         public string Name;
@@ -14,10 +14,13 @@ namespace AndroidSideloader
         public long TransferredBytes;
         public double SpeedMBps;
         public TransferState State = TransferState.Queued;
+        public DateTime? CompletedUtc; // set when the item reaches Done/Failed, for auto-clear
+        public Action Retry;           // re-attempts this single file; set when it fails
     }
 
     // Thread-safe registry of in-flight file transfers. Producers are the transfer
-    // workers (background threads); the consumer is the TransferWindow UI timer.
+    // workers (background threads); the consumer is the TransferStrip UI timer, which
+    // polls Snapshot() and auto-removes finished rows via PurgeCompleted().
     public static class TransferQueue
     {
         private static readonly object _lock = new object();
@@ -30,7 +33,6 @@ namespace AndroidSideloader
             {
                 _items.Add(item);
             }
-            TransferWindow.NotifyActivity();
             return item;
         }
 
@@ -40,6 +42,10 @@ namespace AndroidSideloader
             lock (_lock)
             {
                 item.State = state;
+                if (state == TransferState.Done || state == TransferState.Failed)
+                {
+                    item.CompletedUtc = DateTime.UtcNow;
+                }
             }
         }
 
@@ -65,6 +71,30 @@ namespace AndroidSideloader
             }
         }
 
+        // Auto-clears *successful* rows a short while after they finish, so a "Done" row is
+        // visible briefly then disappears. Failed rows are kept so the user can retry them.
+        public static void PurgeCompleted(double doneSeconds)
+        {
+            DateTime now = DateTime.UtcNow;
+            lock (_lock)
+            {
+                _items.RemoveAll(i =>
+                    i.State == TransferState.Done &&
+                    i.CompletedUtc.HasValue &&
+                    (now - i.CompletedUtc.Value).TotalSeconds >= doneSeconds);
+            }
+        }
+
+        public static void Remove(TransferItem item)
+        {
+            if (item == null) return;
+            lock (_lock)
+            {
+                _items.Remove(item);
+            }
+        }
+
+        // Clears finished rows on demand (both Done and Failed).
         public static void ClearFinished()
         {
             lock (_lock)

--- a/TransferQueue.cs
+++ b/TransferQueue.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Generic;
+
+namespace AndroidSideloader
+{
+    public enum TransferState { Queued, Active, Done, Failed }
+
+    // A single file transfer surfaced in the TransferWindow.
+    public class TransferItem
+    {
+        public string Name;
+        public string Kind;          // "SFTP", "Push", "Pull"
+        public long TotalBytes;
+        public long TransferredBytes;
+        public double SpeedMBps;
+        public TransferState State = TransferState.Queued;
+    }
+
+    // Thread-safe registry of in-flight file transfers. Producers are the transfer
+    // workers (background threads); the consumer is the TransferWindow UI timer.
+    public static class TransferQueue
+    {
+        private static readonly object _lock = new object();
+        private static readonly List<TransferItem> _items = new List<TransferItem>();
+
+        public static TransferItem Add(string name, string kind, long totalBytes)
+        {
+            TransferItem item = new TransferItem { Name = name, Kind = kind, TotalBytes = totalBytes };
+            lock (_lock)
+            {
+                _items.Add(item);
+            }
+            TransferWindow.NotifyActivity();
+            return item;
+        }
+
+        public static void SetState(TransferItem item, TransferState state)
+        {
+            if (item == null) return;
+            lock (_lock)
+            {
+                item.State = state;
+            }
+        }
+
+        public static void Report(TransferItem item, long transferred, double speedMBps)
+        {
+            if (item == null) return;
+            lock (_lock)
+            {
+                item.TransferredBytes = transferred;
+                item.SpeedMBps = speedMBps;
+                if (item.State == TransferState.Queued)
+                {
+                    item.State = TransferState.Active;
+                }
+            }
+        }
+
+        public static List<TransferItem> Snapshot()
+        {
+            lock (_lock)
+            {
+                return new List<TransferItem>(_items);
+            }
+        }
+
+        public static void ClearFinished()
+        {
+            lock (_lock)
+            {
+                _items.RemoveAll(i => i.State == TransferState.Done || i.State == TransferState.Failed);
+            }
+        }
+    }
+}

--- a/TransferStrip.cs
+++ b/TransferStrip.cs
@@ -4,41 +4,54 @@ using System.Windows.Forms;
 
 namespace AndroidSideloader
 {
-    // FileZilla-style popup showing every in-flight file transfer (SFTP / push / pull)
-    // with a live per-file progress bar, speed and status. Non-modal so it never blocks
-    // the app; hides on close and re-shows itself when new transfers start.
-    public class TransferWindow : Form
+    // Integrated, collapsible transfer strip. It overlays the bottom of the games list
+    // whenever files are moving (SFTP / push), themed to match the main window, and hides
+    // itself when idle. Finished rows auto-clear a couple of seconds after they complete.
+    // This is a child of the main form, not a separate window.
+    public class TransferStrip : Panel
     {
-        private static TransferWindow _instance;
-        private static readonly object _instLock = new object();
-
         private readonly ListView _list;
         private readonly Timer _timer;
+        private Control _anchor;                 // control whose bottom edge we sit on (games list)
+        private const int ExpandedHeight = 150;
 
-        private static readonly Color Bg = Color.FromArgb(25, 25, 25);
-        private static readonly Color BgAlt = Color.FromArgb(32, 32, 32);
-        private static readonly Color Fg = Color.White;
-        private static readonly Color HeaderBg = Color.FromArgb(35, 35, 35);
-        private static readonly Color BarBack = Color.FromArgb(52, 52, 52);
-        private static readonly Color Accent = Color.FromArgb(0, 120, 215);
-        private static readonly Color DoneColor = Color.FromArgb(60, 160, 90);
-        private static readonly Color FailColor = Color.FromArgb(200, 70, 70);
+        private readonly Color _bg;
+        private readonly Color _bgAlt;
+        private readonly Color _header;
+        private readonly Color _barBack;
+        private readonly Color _fg;
+        private readonly Color _accent = Color.FromArgb(70, 130, 220);
+        private readonly Color _doneColor = Color.FromArgb(70, 165, 95);
+        private readonly Color _failColor = Color.FromArgb(200, 80, 80);
 
         private sealed class BufferedListView : ListView
         {
             public BufferedListView() { DoubleBuffered = true; }
         }
 
-        private TransferWindow()
+        public TransferStrip(Color themeBack, Color themeFore)
         {
-            Text = "Transfers";
-            ClientSize = new Size(680, 340);
-            MinimumSize = new Size(420, 200);
-            StartPosition = FormStartPosition.CenterScreen;
-            BackColor = Bg;
-            ForeColor = Fg;
-            ShowInTaskbar = true;
-            try { if (Program.form != null && !Program.form.IsDisposed) Icon = Program.form.Icon; } catch { }
+            _bg = themeBack;
+            _bgAlt = Shift(themeBack, 8);
+            _header = Shift(themeBack, 18);
+            _barBack = Shift(themeBack, 28);
+            _fg = themeFore;
+
+            DoubleBuffered = true;
+            BackColor = _header;
+            Visible = false;
+            Padding = new Padding(1, 0, 1, 1);
+
+            Label title = new Label
+            {
+                Text = "  TRANSFERS",
+                Dock = DockStyle.Top,
+                Height = 22,
+                BackColor = _header,
+                ForeColor = _fg,
+                TextAlign = ContentAlignment.MiddleLeft,
+                Font = new Font("Segoe UI", 8.25f, FontStyle.Bold)
+            };
 
             _list = new BufferedListView
             {
@@ -47,85 +60,96 @@ namespace AndroidSideloader
                 FullRowSelect = true,
                 GridLines = false,
                 OwnerDraw = true,
-                BackColor = Bg,
-                ForeColor = Fg,
+                BackColor = _bg,
+                ForeColor = _fg,
                 BorderStyle = BorderStyle.None,
                 HeaderStyle = ColumnHeaderStyle.Nonclickable
             };
             _list.Columns.Add("File", 300);
-            _list.Columns.Add("Size", 90, HorizontalAlignment.Right);
-            _list.Columns.Add("Progress", 140);
+            _list.Columns.Add("Size", 80, HorizontalAlignment.Right);
+            _list.Columns.Add("Progress", 150);
             _list.Columns.Add("Speed", 80, HorizontalAlignment.Right);
             _list.Columns.Add("Status", 70, HorizontalAlignment.Left);
             _list.DrawColumnHeader += OnDrawHeader;
-            _list.DrawItem += (s, e) => { /* per-subitem drawing below */ };
+            _list.DrawItem += (s, e) => { /* handled per-subitem */ };
             _list.DrawSubItem += OnDrawSubItem;
 
-            Panel bottom = new Panel { Dock = DockStyle.Bottom, Height = 40, BackColor = BgAlt };
-            Button clearBtn = new Button
-            {
-                Text = "Clear finished",
-                FlatStyle = FlatStyle.Flat,
-                ForeColor = Fg,
-                BackColor = Color.FromArgb(45, 45, 45),
-                Width = 130,
-                Height = 26,
-                Anchor = AnchorStyles.Right | AnchorStyles.Top
-            };
-            clearBtn.FlatAppearance.BorderColor = Color.FromArgb(70, 70, 70);
-            clearBtn.Location = new Point(bottom.ClientSize.Width - clearBtn.Width - 8, 7);
-            clearBtn.Click += (s, e) => TransferQueue.ClearFinished();
-            bottom.Controls.Add(clearBtn);
-
             Controls.Add(_list);
-            Controls.Add(bottom);
+            Controls.Add(title);
 
-            _timer = new Timer { Interval = 250 };
-            _timer.Tick += (s, e) => RefreshList();
-            _timer.Start();
-
-            FormClosing += (s, e) =>
+            // Right-click menu: retry a failed file, remove a row, or clear finished rows.
+            ContextMenuStrip menu = new ContextMenuStrip { BackColor = _header, ForeColor = _fg };
+            ToolStripMenuItem retryMi = new ToolStripMenuItem("Retry");
+            ToolStripMenuItem removeMi = new ToolStripMenuItem("Remove");
+            ToolStripMenuItem clearMi = new ToolStripMenuItem("Clear finished");
+            retryMi.Click += (s, e) => { TransferItem t = _menuTarget; if (t != null && t.Retry != null) t.Retry(); };
+            removeMi.Click += (s, e) => { if (_menuTarget != null) TransferQueue.Remove(_menuTarget); };
+            clearMi.Click += (s, e) => TransferQueue.ClearFinished();
+            menu.Items.Add(retryMi);
+            menu.Items.Add(removeMi);
+            menu.Items.Add(new ToolStripSeparator());
+            menu.Items.Add(clearMi);
+            menu.Opening += (s, e) =>
             {
-                // Hide (keep the singleton alive) rather than dispose on the X button.
-                if (e.CloseReason == CloseReason.UserClosing)
+                retryMi.Enabled = _menuTarget != null && _menuTarget.State == TransferState.Failed && _menuTarget.Retry != null;
+                removeMi.Enabled = _menuTarget != null;
+            };
+            _list.ContextMenuStrip = menu;
+            _list.MouseDown += (s, e) =>
+            {
+                if (e.Button == MouseButtons.Right)
                 {
-                    e.Cancel = true;
-                    Hide();
+                    ListViewHitTestInfo hit = _list.HitTest(e.Location);
+                    _menuTarget = hit.Item != null ? hit.Item.Tag as TransferItem : null;
                 }
             };
+
+            _timer = new Timer { Interval = 250 };
+            _timer.Tick += (s, e) => Tick();
         }
 
-        // Called from any thread when a transfer is added/updated. Creates and shows the
-        // window on the UI thread if needed.
-        public static void NotifyActivity()
+        private TransferItem _menuTarget;
+
+        // Attaches the strip to a parent form and anchors it to a control's bottom edge.
+        public void AttachTo(Control parent, Control anchor)
         {
-            Form owner = Program.form;
-            if (owner == null || owner.IsDisposed) return;
+            _anchor = anchor;
+            if (parent != null && !parent.IsDisposed)
+            {
+                parent.Controls.Add(this);
+                BringToFront();
+            }
+            _timer.Start();
+        }
+
+        private void Tick()
+        {
             try
             {
-                owner.BeginInvoke((Action)(() =>
+                TransferQueue.PurgeCompleted(2.0);
+                var items = TransferQueue.Snapshot();
+
+                if (items.Count == 0)
                 {
-                    lock (_instLock)
-                    {
-                        if (_instance == null || _instance.IsDisposed)
-                        {
-                            _instance = new TransferWindow();
-                        }
-                    }
-                    if (!_instance.Visible)
-                    {
-                        _instance.Show(owner);
-                    }
-                    _instance.BringToFront();
-                }));
+                    if (Visible) Visible = false;
+                    return;
+                }
+
+                if (_anchor != null && !_anchor.IsDisposed)
+                {
+                    int h = Math.Min(ExpandedHeight, Math.Max(64, _anchor.Height - 30));
+                    SetBounds(_anchor.Left, _anchor.Bottom - h, _anchor.Width, h);
+                }
+
+                if (!Visible) Visible = true;
+                BringToFront();
+                RefreshRows(items);
             }
             catch { }
         }
 
-        private void RefreshList()
+        private void RefreshRows(System.Collections.Generic.List<TransferItem> items)
         {
-            var items = TransferQueue.Snapshot();
-
             _list.BeginUpdate();
             while (_list.Items.Count > items.Count)
             {
@@ -179,15 +203,23 @@ namespace AndroidSideloader
             return mb >= 1024 ? (mb / 1024.0).ToString("0.00") + " GB" : mb.ToString("0.0") + " MB";
         }
 
+        private static Color Shift(Color c, int amt)
+        {
+            return Color.FromArgb(
+                Math.Min(255, Math.Max(0, c.R + amt)),
+                Math.Min(255, Math.Max(0, c.G + amt)),
+                Math.Min(255, Math.Max(0, c.B + amt)));
+        }
+
         private void OnDrawHeader(object sender, DrawListViewColumnHeaderEventArgs e)
         {
-            using (SolidBrush b = new SolidBrush(HeaderBg))
+            using (SolidBrush b = new SolidBrush(_header))
             {
                 e.Graphics.FillRectangle(b, e.Bounds);
             }
             TextRenderer.DrawText(e.Graphics, e.Header.Text, Font, e.Bounds, Color.Gainsboro,
                 TextFormatFlags.Left | TextFormatFlags.VerticalCenter | TextFormatFlags.LeftAndRightPadding);
-            using (Pen p = new Pen(Color.FromArgb(55, 55, 55)))
+            using (Pen p = new Pen(Shift(_bg, 40)))
             {
                 e.Graphics.DrawLine(p, e.Bounds.Left, e.Bounds.Bottom - 1, e.Bounds.Right, e.Bounds.Bottom - 1);
             }
@@ -196,7 +228,7 @@ namespace AndroidSideloader
         private void OnDrawSubItem(object sender, DrawListViewSubItemEventArgs e)
         {
             TransferItem t = e.Item.Tag as TransferItem;
-            Color rowBg = (e.ItemIndex % 2 == 0) ? Bg : BgAlt;
+            Color rowBg = (e.ItemIndex % 2 == 0) ? _bg : _bgAlt;
             using (SolidBrush b = new SolidBrush(rowBg))
             {
                 e.Graphics.FillRectangle(b, e.Bounds);
@@ -206,21 +238,21 @@ namespace AndroidSideloader
             {
                 Rectangle r = e.Bounds;
                 r.Inflate(-4, -5);
-                using (SolidBrush bb = new SolidBrush(BarBack))
+                using (SolidBrush bb = new SolidBrush(_barBack))
                 {
                     e.Graphics.FillRectangle(bb, r);
                 }
                 double frac = t.TotalBytes > 0 ? Math.Max(0, Math.Min(1, (double)t.TransferredBytes / t.TotalBytes)) : 0;
                 Rectangle fill = r;
                 fill.Width = (int)(r.Width * frac);
-                Color barColor = t.State == TransferState.Failed ? FailColor
-                               : t.State == TransferState.Done ? DoneColor
-                               : Accent;
+                Color barColor = t.State == TransferState.Failed ? _failColor
+                               : t.State == TransferState.Done ? _doneColor
+                               : _accent;
                 using (SolidBrush fb = new SolidBrush(barColor))
                 {
                     e.Graphics.FillRectangle(fb, fill);
                 }
-                TextRenderer.DrawText(e.Graphics, (frac * 100).ToString("0.0") + "%", Font, e.Bounds, Fg,
+                TextRenderer.DrawText(e.Graphics, (frac * 100).ToString("0.0") + "%", Font, e.Bounds, _fg,
                     TextFormatFlags.HorizontalCenter | TextFormatFlags.VerticalCenter);
             }
             else
@@ -230,10 +262,10 @@ namespace AndroidSideloader
                 {
                     flags |= TextFormatFlags.Right;
                 }
-                Color txt = Fg;
+                Color txt = _fg;
                 if (e.ColumnIndex == 4 && t != null)
                 {
-                    txt = t.State == TransferState.Done ? Color.FromArgb(120, 200, 140)
+                    txt = t.State == TransferState.Done ? Color.FromArgb(120, 205, 145)
                         : t.State == TransferState.Failed ? Color.FromArgb(230, 120, 120)
                         : t.State == TransferState.Active ? Color.FromArgb(120, 180, 240)
                         : Color.Gainsboro;

--- a/TransferWindow.cs
+++ b/TransferWindow.cs
@@ -1,0 +1,254 @@
+using System;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace AndroidSideloader
+{
+    // FileZilla-style popup showing every in-flight file transfer (SFTP / push / pull)
+    // with a live per-file progress bar, speed and status. Non-modal so it never blocks
+    // the app; hides on close and re-shows itself when new transfers start.
+    public class TransferWindow : Form
+    {
+        private static TransferWindow _instance;
+        private static readonly object _instLock = new object();
+
+        private readonly ListView _list;
+        private readonly Timer _timer;
+
+        private static readonly Color Bg = Color.FromArgb(25, 25, 25);
+        private static readonly Color BgAlt = Color.FromArgb(32, 32, 32);
+        private static readonly Color Fg = Color.White;
+        private static readonly Color HeaderBg = Color.FromArgb(35, 35, 35);
+        private static readonly Color BarBack = Color.FromArgb(52, 52, 52);
+        private static readonly Color Accent = Color.FromArgb(0, 120, 215);
+        private static readonly Color DoneColor = Color.FromArgb(60, 160, 90);
+        private static readonly Color FailColor = Color.FromArgb(200, 70, 70);
+
+        private sealed class BufferedListView : ListView
+        {
+            public BufferedListView() { DoubleBuffered = true; }
+        }
+
+        private TransferWindow()
+        {
+            Text = "Transfers";
+            ClientSize = new Size(680, 340);
+            MinimumSize = new Size(420, 200);
+            StartPosition = FormStartPosition.CenterScreen;
+            BackColor = Bg;
+            ForeColor = Fg;
+            ShowInTaskbar = true;
+            try { if (Program.form != null && !Program.form.IsDisposed) Icon = Program.form.Icon; } catch { }
+
+            _list = new BufferedListView
+            {
+                Dock = DockStyle.Fill,
+                View = View.Details,
+                FullRowSelect = true,
+                GridLines = false,
+                OwnerDraw = true,
+                BackColor = Bg,
+                ForeColor = Fg,
+                BorderStyle = BorderStyle.None,
+                HeaderStyle = ColumnHeaderStyle.Nonclickable
+            };
+            _list.Columns.Add("File", 300);
+            _list.Columns.Add("Size", 90, HorizontalAlignment.Right);
+            _list.Columns.Add("Progress", 140);
+            _list.Columns.Add("Speed", 80, HorizontalAlignment.Right);
+            _list.Columns.Add("Status", 70, HorizontalAlignment.Left);
+            _list.DrawColumnHeader += OnDrawHeader;
+            _list.DrawItem += (s, e) => { /* per-subitem drawing below */ };
+            _list.DrawSubItem += OnDrawSubItem;
+
+            Panel bottom = new Panel { Dock = DockStyle.Bottom, Height = 40, BackColor = BgAlt };
+            Button clearBtn = new Button
+            {
+                Text = "Clear finished",
+                FlatStyle = FlatStyle.Flat,
+                ForeColor = Fg,
+                BackColor = Color.FromArgb(45, 45, 45),
+                Width = 130,
+                Height = 26,
+                Anchor = AnchorStyles.Right | AnchorStyles.Top
+            };
+            clearBtn.FlatAppearance.BorderColor = Color.FromArgb(70, 70, 70);
+            clearBtn.Location = new Point(bottom.ClientSize.Width - clearBtn.Width - 8, 7);
+            clearBtn.Click += (s, e) => TransferQueue.ClearFinished();
+            bottom.Controls.Add(clearBtn);
+
+            Controls.Add(_list);
+            Controls.Add(bottom);
+
+            _timer = new Timer { Interval = 250 };
+            _timer.Tick += (s, e) => RefreshList();
+            _timer.Start();
+
+            FormClosing += (s, e) =>
+            {
+                // Hide (keep the singleton alive) rather than dispose on the X button.
+                if (e.CloseReason == CloseReason.UserClosing)
+                {
+                    e.Cancel = true;
+                    Hide();
+                }
+            };
+        }
+
+        // Called from any thread when a transfer is added/updated. Creates and shows the
+        // window on the UI thread if needed.
+        public static void NotifyActivity()
+        {
+            Form owner = Program.form;
+            if (owner == null || owner.IsDisposed) return;
+            try
+            {
+                owner.BeginInvoke((Action)(() =>
+                {
+                    lock (_instLock)
+                    {
+                        if (_instance == null || _instance.IsDisposed)
+                        {
+                            _instance = new TransferWindow();
+                        }
+                    }
+                    if (!_instance.Visible)
+                    {
+                        _instance.Show(owner);
+                    }
+                    _instance.BringToFront();
+                }));
+            }
+            catch { }
+        }
+
+        private void RefreshList()
+        {
+            var items = TransferQueue.Snapshot();
+
+            _list.BeginUpdate();
+            while (_list.Items.Count > items.Count)
+            {
+                _list.Items.RemoveAt(_list.Items.Count - 1);
+            }
+            for (int i = 0; i < items.Count; i++)
+            {
+                TransferItem t = items[i];
+                ListViewItem row;
+                if (i < _list.Items.Count)
+                {
+                    row = _list.Items[i];
+                }
+                else
+                {
+                    row = new ListViewItem();
+                    row.SubItems.Add("");
+                    row.SubItems.Add("");
+                    row.SubItems.Add("");
+                    row.SubItems.Add("");
+                    _list.Items.Add(row);
+                }
+
+                row.Tag = t;
+                row.SubItems[0].Text = t.Name;
+                row.SubItems[1].Text = FormatSize(t.TotalBytes);
+                double pct = t.TotalBytes > 0 ? (t.TransferredBytes * 100.0 / t.TotalBytes) : 0;
+                row.SubItems[2].Text = pct.ToString("0.0") + "%";
+                row.SubItems[3].Text = t.State == TransferState.Active ? t.SpeedMBps.ToString("0.0") + " MB/s" : "";
+                row.SubItems[4].Text = StatusText(t.State);
+            }
+            _list.EndUpdate();
+        }
+
+        private static string StatusText(TransferState s)
+        {
+            switch (s)
+            {
+                case TransferState.Queued: return "Queued";
+                case TransferState.Active: return "Active";
+                case TransferState.Done: return "Done";
+                case TransferState.Failed: return "Failed";
+                default: return "";
+            }
+        }
+
+        private static string FormatSize(long bytes)
+        {
+            if (bytes <= 0) return "";
+            double mb = bytes / 1048576.0;
+            return mb >= 1024 ? (mb / 1024.0).ToString("0.00") + " GB" : mb.ToString("0.0") + " MB";
+        }
+
+        private void OnDrawHeader(object sender, DrawListViewColumnHeaderEventArgs e)
+        {
+            using (SolidBrush b = new SolidBrush(HeaderBg))
+            {
+                e.Graphics.FillRectangle(b, e.Bounds);
+            }
+            TextRenderer.DrawText(e.Graphics, e.Header.Text, Font, e.Bounds, Color.Gainsboro,
+                TextFormatFlags.Left | TextFormatFlags.VerticalCenter | TextFormatFlags.LeftAndRightPadding);
+            using (Pen p = new Pen(Color.FromArgb(55, 55, 55)))
+            {
+                e.Graphics.DrawLine(p, e.Bounds.Left, e.Bounds.Bottom - 1, e.Bounds.Right, e.Bounds.Bottom - 1);
+            }
+        }
+
+        private void OnDrawSubItem(object sender, DrawListViewSubItemEventArgs e)
+        {
+            TransferItem t = e.Item.Tag as TransferItem;
+            Color rowBg = (e.ItemIndex % 2 == 0) ? Bg : BgAlt;
+            using (SolidBrush b = new SolidBrush(rowBg))
+            {
+                e.Graphics.FillRectangle(b, e.Bounds);
+            }
+
+            if (e.ColumnIndex == 2 && t != null)
+            {
+                Rectangle r = e.Bounds;
+                r.Inflate(-4, -5);
+                using (SolidBrush bb = new SolidBrush(BarBack))
+                {
+                    e.Graphics.FillRectangle(bb, r);
+                }
+                double frac = t.TotalBytes > 0 ? Math.Max(0, Math.Min(1, (double)t.TransferredBytes / t.TotalBytes)) : 0;
+                Rectangle fill = r;
+                fill.Width = (int)(r.Width * frac);
+                Color barColor = t.State == TransferState.Failed ? FailColor
+                               : t.State == TransferState.Done ? DoneColor
+                               : Accent;
+                using (SolidBrush fb = new SolidBrush(barColor))
+                {
+                    e.Graphics.FillRectangle(fb, fill);
+                }
+                TextRenderer.DrawText(e.Graphics, (frac * 100).ToString("0.0") + "%", Font, e.Bounds, Fg,
+                    TextFormatFlags.HorizontalCenter | TextFormatFlags.VerticalCenter);
+            }
+            else
+            {
+                TextFormatFlags flags = TextFormatFlags.VerticalCenter | TextFormatFlags.LeftAndRightPadding | TextFormatFlags.EndEllipsis;
+                if (e.Header != null && e.Header.TextAlign == HorizontalAlignment.Right)
+                {
+                    flags |= TextFormatFlags.Right;
+                }
+                Color txt = Fg;
+                if (e.ColumnIndex == 4 && t != null)
+                {
+                    txt = t.State == TransferState.Done ? Color.FromArgb(120, 200, 140)
+                        : t.State == TransferState.Failed ? Color.FromArgb(230, 120, 120)
+                        : t.State == TransferState.Active ? Color.FromArgb(120, 180, 240)
+                        : Color.Gainsboro;
+                }
+                TextRenderer.DrawText(e.Graphics, e.SubItem.Text, Font, e.Bounds, txt, flags);
+            }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                try { _timer?.Stop(); _timer?.Dispose(); } catch { }
+            }
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/Utilities/ChunkedDownloader.cs
+++ b/Utilities/ChunkedDownloader.cs
@@ -366,8 +366,9 @@ namespace AndroidSideloader.Utilities
                     }
                 };
 
-                // Determine concurrency
-                int maxConcurrency = _settings.SingleThreadMode ? 1 : Math.Min(4, files.Count);
+                // Determine concurrency (files downloaded in parallel).
+                int desiredThreads = _settings.DownloadThreads > 0 ? _settings.DownloadThreads : 6;
+                int maxConcurrency = _settings.SingleThreadMode ? 1 : Math.Min(desiredThreads, Math.Max(1, files.Count));
                 var semaphore = new SemaphoreSlim(maxConcurrency, maxConcurrency);
 
                 var tasks = new List<Task<string>>();

--- a/Utilities/SettingsManager.cs
+++ b/Utilities/SettingsManager.cs
@@ -124,9 +124,12 @@ namespace AndroidSideloader.Utilities
         public bool CustomBackupDir { get; set; } = false;
         public string BackupDir { get; set; } = string.Empty;
         public bool SingleThreadMode { get; set; } = false;
-        // Number of files transferred in parallel when multithreading is enabled
-        // (download parts, and OBB files over SFTP). Ignored when SingleThreadMode is on.
+        // Number of download parts fetched in parallel when multithreading is enabled.
+        // Ignored when SingleThreadMode is on.
         public int DownloadThreads { get; set; } = 6;
+        // Number of OBB files uploaded concurrently over SFTP (FileZilla-style queue).
+        // Kept modest so the on-device sshd / FUSE storage is not overwhelmed.
+        public int SftpThreads { get; set; } = 3;
         public bool VirtualFilesystemCompatibility { get; set; } = false;
         public bool UpdateSettings { get; set; } = true;
         public string UUID { get; set; } = Guid.NewGuid().ToString();
@@ -283,6 +286,7 @@ namespace AndroidSideloader.Utilities
             BackupDir = string.Empty;
             SingleThreadMode = false;
             DownloadThreads = 6;
+            SftpThreads = 3;
             VirtualFilesystemCompatibility = false;
             UpdateSettings = true;
             UUID = Guid.NewGuid().ToString();

--- a/Utilities/SettingsManager.cs
+++ b/Utilities/SettingsManager.cs
@@ -141,6 +141,16 @@ namespace AndroidSideloader.Utilities
         public int GalleryTileSize { get; set; } = 100;
         public string ConfigUrl { get; set; } = string.Empty;
 
+        // SFTP fast transfers (rooted headsets running an SSH server).
+        // Empty host = auto-detect from ADB; port 0 = probe 22, 8022, 2222;
+        // empty key path = try ~/.ssh/quest_root, id_ed25519, id_rsa.
+        public bool EnableSftpTransfers { get; set; } = true;
+        public string SftpHost { get; set; } = string.Empty;
+        public int SftpPort { get; set; } = 0;
+        public string SftpUsername { get; set; } = "root";
+        public string SftpPassword { get; set; } = string.Empty;
+        public string SftpPrivateKeyPath { get; set; } = string.Empty;
+
         // Window state persistence
         public int WindowX { get; set; } = -1;
         public int WindowY { get; set; } = -1;
@@ -285,6 +295,12 @@ namespace AndroidSideloader.Utilities
             UseGalleryView = true;
             GalleryTileSize = 100;
             ConfigUrl = string.Empty;
+            EnableSftpTransfers = true;
+            SftpHost = string.Empty;
+            SftpPort = 0;
+            SftpUsername = "root";
+            SftpPassword = string.Empty;
+            SftpPrivateKeyPath = string.Empty;
             WindowX = -1;
             WindowY = -1;
             WindowWidth = -1;

--- a/Utilities/SettingsManager.cs
+++ b/Utilities/SettingsManager.cs
@@ -123,7 +123,10 @@ namespace AndroidSideloader.Utilities
         public bool CustomDownloadDir { get; set; } = false;
         public bool CustomBackupDir { get; set; } = false;
         public string BackupDir { get; set; } = string.Empty;
-        public bool SingleThreadMode { get; set; } = true;
+        public bool SingleThreadMode { get; set; } = false;
+        // Number of files transferred in parallel when multithreading is enabled
+        // (download parts, and OBB files over SFTP). Ignored when SingleThreadMode is on.
+        public int DownloadThreads { get; set; } = 6;
         public bool VirtualFilesystemCompatibility { get; set; } = false;
         public bool UpdateSettings { get; set; } = true;
         public string UUID { get; set; } = Guid.NewGuid().ToString();
@@ -278,7 +281,8 @@ namespace AndroidSideloader.Utilities
             CustomDownloadDir = false;
             CustomBackupDir = false;
             BackupDir = string.Empty;
-            SingleThreadMode = true;
+            SingleThreadMode = false;
+            DownloadThreads = 6;
             VirtualFilesystemCompatibility = false;
             UpdateSettings = true;
             UUID = Guid.NewGuid().ToString();

--- a/build.cmd
+++ b/build.cmd
@@ -11,7 +11,7 @@ IF NOT EXIST %VSWHERE% SET VSWHERE="%ProgramFiles%\Microsoft Visual Studio\Insta
 
 SET MSBUILD=
 IF EXIST %VSWHERE% (
-    FOR /F "usebackq delims=" %%P IN (`%VSWHERE% -latest -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe`) DO (
+    FOR /F "usebackq delims=" %%P IN (`%VSWHERE% -latest -products * -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe`) DO (
         SET MSBUILD="%%P"
         GOTO :msbuild_found
     )

--- a/packages.config
+++ b/packages.config
@@ -1,24 +1,31 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AdvancedSharpAdbClient" version="3.5.15" targetFramework="net452" />
+  <package id="BouncyCastle.Cryptography" version="2.4.0" targetFramework="net48" />
   <package id="Costura.Fody" version="5.7.0" targetFramework="net452" developmentDependency="true" />
   <package id="Fody" version="6.8.1" targetFramework="net452" developmentDependency="true" />
   <package id="Microsoft.NETCore.Platforms" version="7.0.4" targetFramework="net452" />
   <package id="Microsoft.Web.WebView2" version="1.0.2478.35" targetFramework="net452" />
   <package id="NETStandard.Library" version="2.0.3" targetFramework="net452" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="1.0.0" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net452" />
+  <package id="SSH.NET" version="2024.2.0" targetFramework="net48" />
+  <package id="System.Buffers" version="4.5.1" targetFramework="net48" />
   <package id="System.Collections" version="4.3.0" targetFramework="net452" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net452" />
   <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net452" />
   <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="net452" />
   <package id="System.Diagnostics.Tracing" version="4.3.0" targetFramework="net452" />
+  <package id="System.Formats.Asn1" version="8.0.1" targetFramework="net48" />
   <package id="System.Globalization" version="4.3.0" targetFramework="net452" />
   <package id="System.IO" version="4.3.0" targetFramework="net452" />
   <package id="System.IO.Compression" version="4.3.0" targetFramework="net452" />
   <package id="System.Linq" version="4.3.0" targetFramework="net452" />
   <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net452" />
+  <package id="System.Memory" version="4.5.5" targetFramework="net48" />
   <package id="System.Net.Http" version="4.3.4" targetFramework="net452" />
   <package id="System.Net.Primitives" version="4.3.1" targetFramework="net452" />
+  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net48" />
   <package id="System.ObjectModel" version="4.3.0" targetFramework="net452" />
   <package id="System.Reflection" version="4.3.0" targetFramework="net452" />
   <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net452" />
@@ -27,6 +34,7 @@
   <package id="System.Runtime" version="4.3.1" targetFramework="net452" />
   <package id="System.Runtime.Extensions" version="4.3.1" targetFramework="net452" />
   <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net452" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" targetFramework="net48" />
   <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net452" />
   <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="net452" />
   <package id="System.Text.Encoding" version="4.3.0" targetFramework="net452" />
@@ -34,7 +42,9 @@
   <package id="System.Text.RegularExpressions" version="4.3.1" targetFramework="net452" />
   <package id="System.Threading" version="4.3.0" targetFramework="net452" />
   <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net452" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.2" targetFramework="net48" />
   <package id="System.Threading.Timer" version="4.3.0" targetFramework="net452" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net48" />
   <package id="System.Xml.ReaderWriter" version="4.3.1" targetFramework="net452" />
   <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
## Overview

Overhauls how large game/OBB data moves in and out of the app: downloads and SFTP OBB uploads are concurrent, every transfer is shown live in an integrated strip, and the whole path is hardened so it can't softlock, silently drop files, or report a bogus failure. Tested end to end on a wireless Quest 3 (metadata sync, multi-part download, multi-GB OBB set over SFTP, install, reconnect across restarts).

---

## Why SFTP instead of `adb push`?

For multi-GB OBBs, a direct SFTP session to an on-device `sshd` (rooted headsets) is **several times faster** than `adb push`, and the difference grows with size:

- **`adb push` is throttled by the adb sync protocol.** It streams a single channel in small chunks, each acknowledged, multiplexed through the adb daemon on both ends. Over **wireless adb** especially, that overhead caps throughput far below the link's real capacity.
- **SFTP streams raw over TCP** to `sshd` with large windows and far less per-chunk handshaking, so it saturates the Wi-Fi/USB link instead of the protocol.
- **SFTP parallelizes; adb's sync channel does not.** A single adb server serializes sync operations, so you can't meaningfully push multiple files at once. SFTP lets us open several independent connections and run a bounded concurrent queue.

Measured here: **~62.8 MB/s** for a 9.5 GB OBB over 3 SFTP connections; `adb push` over wireless is a fraction of that.

**Trade-off / fallback:** SFTP needs root + a reachable on-device `sshd`. Detection is automatic and everything degrades gracefully — no root, no server, or a total SFTP failure falls straight back to `adb push`.

---

## Multi-threaded downloads

`ChunkedDownloader` fetches a game's split archive (`.7z.001`, `.7z.002`, …) over a local `rclone serve http` proxy. Concurrency was hardcoded to `Min(4, parts)` and gated behind `SingleThreadMode`, which defaulted **on** — so downloads were single-threaded out of the box.

- Concurrency is now a **`DownloadThreads`** setting (default **6**), clamped to the part count.
- **`SingleThreadMode` defaults to off**; turning it on still forces a single stream.
- Public-mirror note: its proxy runs `--tpslimit 1.0 --tpslimit-burst 3`, so rclone throttles *opening* new files; extra threads still overlap in-flight streams but won't scale linearly there. Private mirrors and SFTP have no such cap.

## SFTP OBB transfers — concurrent, bounded, and self-healing

- **Bounded work-stealing queue.** `SftpThreads` workers (default **3**) each hold one connection and pull the next file from a shared queue — at most N files move at once regardless of OBB count (the FileZilla model). Gentle on the device `sshd`/FUSE storage.
- **Never hangs.** Each upload uses a **60s `OperationTimeout`**, so a wedged channel throws instead of blocking forever. Previously a single stuck file could freeze an entire multi-hundred-file OBB upload.
- **Auto-retry ×3** on a fresh reconnection with backoff.
- **Post-upload verification:** after each file the remote path is `stat`'d for **exact size**; a file that isn't there or is truncated is a failure and is retried, never reported as done.
- **Failure isolation:** one bad file no longer aborts the batch; it's left **Failed with a per-file Retry** (`SFTP.RetryUpload`) instead of re-pushing the whole set. Only a total failure falls back to `adb push`.
- **Perms:** best-effort `chmod -R 0777` + `restorecon` so the game can read files an `sshd` wrote as root.

## Integrated transfer strip

Replaces the earlier popup with a themed, collapsible strip that overlays the bottom of the games list **only while files move**, then hides. One row per file (File · Size · live progress bar · Speed · Status). Successful rows auto-clear; failed rows stay with a **right-click Retry / Remove / Clear finished** menu. Fed by both SFTP and `adb push`.

## Install verification

`AdvancedSharpAdbClient` throws **"An unknown error occurred."** whenever it can't parse `pm install`'s result — which happens even when the APK installed fine. On an install error the app now verifies against the device (APK package + version code via `aapt`, matched against the installed version) and reports success when it really landed. A failed *upgrade* still fails.

---

## Reliability fixes (reported as "freezes")

| Symptom | Root cause | Fix |
|---|---|---|
| Window locks for tens of seconds after connect | `UpdateQuestInfoPanel` ran `adb shell getprop/df` on the UI thread | Moved off the UI thread |
| Hangs indefinitely mid-operation | `RunAdbCommandToString` had no timeout; Android `df` can wedge on a bad mount | Safety timeout on shell commands; transfers/backup/restore/install exempt; async reads also fix a latent `ReadToEnd` deadlock |
| Wireless device drops every launch | Startup hard-killed every `adb.exe`, tearing down the running server + its `adb connect` session | Reuse the running server (`start-server`) instead of killing it |
| Looks frozen but idle | A modal dialog opened behind another window with `ShowInTaskbar = false` | Dialogs are `TopMost`, shown in taskbar, brought to front |

## Build

`build.cmd`'s `vswhere` now passes `-products *`, so it finds MSBuild in a VS **BuildTools** install, not just full editions.

## New settings

| Setting | Default | Purpose |
|---|---|---|
| `DownloadThreads` | 6 | Parallel download parts |
| `SftpThreads` | 3 | Concurrent SFTP OBB uploads |
| `SingleThreadMode` | now `false` | Master switch; forces single-stream everywhere when on |

Missing settings fall back to these defaults, so existing `settings.json` files need no migration. No new NuGet dependencies.

---
_Supersedes #208 — resubmitted after an account migration; branch and commits are identical._