### PR TITLE
Stop ADB polling and shut down server when sideloading is disabled

### DIFF
--- a/MainForm.cs
+++ b/MainForm.cs
@@ -7443,6 +7443,13 @@ function onYouTubeIframeAPIReady() {
                 settings.DeleteAllAfterInstall = false;
                 btnNoDevice.Text = "ENABLE SIDELOADING";
                 UpdateStatusLabels();
+
+                // Sideloading is now off, so nothing needs ADB. Shut the ADB server down
+                // so it stops running in the background (the device-check poll is also
+                // skipped while in this mode). It restarts on demand the next time a
+                // command runs after sideloading is re-enabled.
+                DeviceConnected = false;
+                _ = Task.Run(() => ADB.RunAdbCommandToString("kill-server"));
             }
 
             settings.Save();
@@ -10208,6 +10215,11 @@ function onYouTubeIframeAPIReady() {
         }
         private async void timer_DeviceCheck(object sender, EventArgs e)
         {
+            // Skip the background "adb devices" poll entirely when the user has turned off
+            // sideloading. In that mode we deliberately don't touch ADB, so we avoid the
+            // per-second adb spawns that spike CPU on low-end machines.
+            if (settings.NodeviceMode) return;
+
             // Skip if a device is connected, we're in the middle of loading or other operations
             if (DeviceConnected || isLoading || isinstalling || isuploading) return;
 


### PR DESCRIPTION
The Disable Sideloading toggle previously only hid install actions: the 1-second device-check timer kept running "adb devices" and the ADB server stayed alive, spiking CPU on low-end machines even when the user had opted out of touching any device.

- timer_DeviceCheck now returns early when NodeviceMode is on, so the background poll no longer spawns adb every second in that mode.
- Toggling Disable Sideloading on now runs "kill-server" so the ADB server stops running in the background; it restarts on demand once sideloading is re-enabled and the poll resumes.
