### PR TITLE
Stop background ADB polling and shut down ADB when sideloading is dis…

### DIFF
--- a/MainForm.cs
+++ b/MainForm.cs
@@ -960,6 +960,18 @@ namespace AndroidSideloader
             changeTitlebarToDevice();
             UpdateStatusLabels();
 
+            // If the app launched with sideloading already disabled, the startup scan
+            // above still ran CheckForDevice / listAppsBtn / UpdateQuestInfoPanel, so the
+            // panel shows a device-info snapshot (device list, battery, installed apps,
+            // storage). Now shut the ADB server down so it doesn't keep running in the
+            // background while sideloading is off (the per-second poll is already skipped
+            // in this mode). It restarts on demand once sideloading is re-enabled.
+            if (settings.NodeviceMode)
+            {
+                DeviceConnected = false;
+                _ = Task.Run(() => ADB.RunAdbCommandToString("kill-server"));
+            }
+
             // Load saved download queue and offer to resume
             LoadQueueFromSettings();
             if (gamesQueueList.Count > 0 && !isOffline)
@@ -7418,7 +7430,7 @@ function onYouTubeIframeAPIReady() {
             OpenDirectory(pathToOpen);
         }
 
-        private void btnNoDevice_Click(object sender, EventArgs e)
+        private async void btnNoDevice_Click(object sender, EventArgs e)
         {
             bool currentStatus = settings.NodeviceMode || false;
 
@@ -7442,17 +7454,62 @@ function onYouTubeIframeAPIReady() {
                 settings.NodeviceMode = true;
                 settings.DeleteAllAfterInstall = false;
                 btnNoDevice.Text = "ENABLE SIDELOADING";
-                UpdateStatusLabels();
 
-                // Sideloading is now off, so nothing needs ADB. Shut the ADB server down
-                // so it stops running in the background (the device-check poll is also
-                // skipped while in this mode). It restarts on demand the next time a
-                // command runs after sideloading is re-enabled.
-                DeviceConnected = false;
-                _ = Task.Run(() => ADB.RunAdbCommandToString("kill-server"));
+                // Sideloading is now off. Before we stop ADB, grab one last device-info
+                // snapshot (device list, battery, installed apps, storage) so the user
+                // can still see what's on the headset while in this mode, then shut the
+                // ADB server down so it stops running in the background (the device-check
+                // poll is also skipped while in this mode). It restarts on demand the
+                // next time a command runs after sideloading is re-enabled.
+                await SnapshotDeviceInfoThenStopAdb();
+
+                UpdateStatusLabels();
             }
 
             settings.Save();
+        }
+
+        /// <summary>
+        /// Pulls a fresh device-info snapshot (device list + battery, installed apps,
+        /// model/firmware/storage) so it stays visible on the panel even while
+        /// sideloading is disabled, then shuts the ADB server down so nothing keeps
+        /// running in the background. Called when the user turns sideloading off at
+        /// runtime; startup performs the equivalent snapshot as part of its device
+        /// scan before killing the server.
+        /// </summary>
+        private async Task SnapshotDeviceInfoThenStopAdb()
+        {
+            try
+            {
+                // Optimistically treat the device as connected so CheckForDevice and
+                // UpdateQuestInfoPanel actually query it for the snapshot even though
+                // sideloading may already be flagged off.
+                DeviceConnected = true;
+
+                // Device list + battery, and (via CheckForDevice) the quest info panel
+                // (model / firmware / storage).
+                _ = await CheckForDevice();
+
+                bool hasDevice = Devices.Count > 0 && Devices[0].Length > 1 && !Devices.Contains("unauthorized");
+                if (hasDevice)
+                {
+                    // Installed-apps list.
+                    await Task.Run(() => listAppsBtn());
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"Failed to snapshot device info before stopping ADB: {ex.Message}", LogLevel.ERROR);
+            }
+            finally
+            {
+                // The snapshot is captured and the info panel keeps showing it. Now stop
+                // the ADB server so it isn't left running in the background while
+                // sideloading is disabled. It restarts on demand once sideloading is
+                // re-enabled and the poll resumes.
+                DeviceConnected = false;
+                await Task.Run(() => ADB.RunAdbCommandToString("kill-server"));
+            }
         }
 
         private async void btnLocalLibrary_Click(object sender, EventArgs e)

--- a/MainForm.cs
+++ b/MainForm.cs
@@ -7443,6 +7443,13 @@ function onYouTubeIframeAPIReady() {
                 settings.DeleteAllAfterInstall = false;
                 btnNoDevice.Text = "ENABLE SIDELOADING";
                 UpdateStatusLabels();
+
+                // Sideloading is now off, so nothing needs ADB. Shut the ADB server down
+                // so it stops running in the background (the device-check poll is also
+                // skipped while in this mode). It restarts on demand the next time a
+                // command runs after sideloading is re-enabled.
+                DeviceConnected = false;
+                _ = Task.Run(() => ADB.RunAdbCommandToString("kill-server"));
             }
 
             settings.Save();
@@ -10208,6 +10215,11 @@ function onYouTubeIframeAPIReady() {
         }
         private async void timer_DeviceCheck(object sender, EventArgs e)
         {
+            // Skip the background "adb devices" poll entirely when the user has turned off
+            // sideloading. In that mode we deliberately don't touch ADB, so we avoid the
+            // per-second adb spawns that spike CPU on low-end machines.
+            if (settings.NodeviceMode) return;
+
             // Skip if a device is connected, we're in the middle of loading or other operations
             if (DeviceConnected || isLoading || isinstalling || isuploading) return;
 


### PR DESCRIPTION
…abled

## Summary

Fixes #201.

"Disable Sideloading" mode currently only hides the install/uninstall actions — it doesn't stop the app from touching ADB. The 1-second device-check timer keeps running `adb devices`, and the ADB server stays alive, so Rookie keeps spawning adb every second and drives up CPU usage even when the user has explicitly opted out of connecting a device. That's the high-CPU / "spawns a console every few seconds" behavior reported in #201.

This makes the existing toggle actually mean "leave ADB alone."

## Changes

- **`timer_DeviceCheck`** now returns early when `NodeviceMode` is on, so the background device poll no longer runs while sideloading is disabled.
- **Toggling Disable Sideloading on** now calls `kill-server`, so the ADB server is shut down instead of idling in the background. It restarts on demand the next time an ADB command runs after sideloading is re-enabled, and the poll resumes normally.

Downloads still work in this mode, so it doubles as a low-CPU, download-only setup. The mode already persists across restarts, so enabling it once is enough.

## Why not a `--nodevice` launch flag (as suggested in #201)

The app already has a user-facing "Disable Sideloading" toggle for exactly this intent; it just wasn't wired to stop the polling or release ADB. Fixing the toggle covers the requester's use case (download-only, minimal CPU) without adding a separate command-line switch to document and maintain.

## Testing / notes

- Change is limited to `MainForm.cs` (+12 lines): one early-return guard and one `kill-server` call on the existing toggle path.
- `kill-server` runs off the UI thread (`Task.Run`) so the toggle stays responsive.
- Not built in this environment (net452 WinForms) — please compile on Windows before merging.
